### PR TITLE
Catch up develop: AGENTS, Calendar tests, EXIF fix, DNG support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guidance for AI coding agents working in this repository.
 Swift Package providing the `ImageMetadata` library and the `imgmd` macOS CLI. It reads (read-only) image metadata via Apple's ImageIO framework, so supported formats and tags are constrained to what ImageIO exposes.
 
 - swift-tools-version: 6.2
-- Platforms: macOS 14, iOS 17, watchOS 10, tvOS 17
+- Platforms: macOS 15, iOS 18, watchOS 11, tvOS 18
 - Default localization: en-US
 - Upcoming feature `InternalImportsByDefault` is enabled package-wide (see the loop at the bottom of `Package.swift`). This means `import Foo` is internal by default — use `public import` in source files when a type from the imported module appears in a public API.
 
@@ -37,19 +37,19 @@ The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCo
 
 1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
 2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
-3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS` structs only when the matching `MetadataOptions` flag is set.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG` structs only when the matching `MetadataOptions` flag is set.
 
-`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
 
 ### The `Metadata` protocol
 
-Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties.
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes.
 
 ### Sub-metadata structure
 
 Each metadata family lives in its own folder and follows the same pattern:
 
-- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
 - `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
 - `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
 
@@ -62,6 +62,7 @@ Each metadata family lives in its own folder and follows the same pattern:
 `Sources/imgmd/imgmd.swift` is a single `ParsableCommand`. The flag-to-option mapping lives in `run()`:
 - `--basic` forces `MetadataOptions.none`.
 - If no metadata flag is set, defaults to `.all`.
+- For each input file the CLI also auto-adds `.dng` to that file's options when its UTI conforms to `UTType.dng` (looked up via `URL.resourceValues(forKeys: [.contentTypeKey])`). `--basic` suppresses this auto-include.
 - `--debug` short-circuits to printing the raw ImageIO dictionary via `ImageMetadata.getProperties(url:)`.
 
 ## Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project
+
+Swift Package providing the `ImageMetadata` library and the `imgmd` macOS CLI. It reads (read-only) image metadata via Apple's ImageIO framework, so supported formats and tags are constrained to what ImageIO exposes.
+
+- swift-tools-version: 6.2
+- Platforms: macOS 14, iOS 17, watchOS 10, tvOS 17
+- Default localization: en-US
+- Upcoming feature `InternalImportsByDefault` is enabled package-wide (see the loop at the bottom of `Package.swift`). This means `import Foo` is internal by default — use `public import` in source files when a type from the imported module appears in a public API.
+
+## Common commands
+
+```sh
+swift build                  # debug build
+swift test                   # run all tests (Swift Testing, not XCTest)
+swift test --filter EXIFTests                    # run a single test struct
+swift test --filter EXIFTests/apertureValue      # run a single test
+make build                   # release build into ./.build
+make install                 # release build + install imgmd to /usr/local/bin
+make clean                   # rm -rf ./.build
+```
+
+The `imgmd` binary can also be exercised directly during development:
+
+```sh
+swift run imgmd ./Sources/Shared/Resources/WindowAtLeGras.jpg
+```
+
+## Architecture
+
+### Library layout
+
+The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCopyPropertiesAtIndex` in strongly-typed, `Codable` Swift values. The flow is:
+
+1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
+2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS` structs only when the matching `MetadataOptions` flag is set.
+
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+
+### The `Metadata` protocol
+
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties.
+
+### Sub-metadata structure
+
+Each metadata family lives in its own folder and follows the same pattern:
+
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
+- `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
+
+### Errors
+
+`MetadataError` and `ImageFileError` are the only public error types. `ImageFileError` uses typed throws (`throws(ImageFileError)`) and carries a URL plus an enum code; `ImageMetadata`'s init chain also uses typed throws (`throws(MetadataError)`). Preserve typed-throws signatures when modifying these initializers — callers depend on them.
+
+### CLI (`imgmd`)
+
+`Sources/imgmd/imgmd.swift` is a single `ParsableCommand`. The flag-to-option mapping lives in `run()`:
+- `--basic` forces `MetadataOptions.none`.
+- If no metadata flag is set, defaults to `.all`.
+- `--debug` short-circuits to printing the raw ImageIO dictionary via `ImageMetadata.getProperties(url:)`.
+
+## Tests
+
+Tests use **Swift Testing** (`import Testing`, `@Test`), not XCTest. Two test targets:
+
+- `ImageMetadataTests` — unit tests for each metadata family. Most tests construct an `NSDictionary` of `kCGImageProperty*` keys directly (see `EXIFTests.sampleRawEXIF()`) so they don't need real image files. They `@testable import` both `ImageMetadata` and `Shared`.
+- `imgmdTests` — tests for the CLI target.
+
+Test fixtures (sample JPEGs) live in `Sources/Shared/Resources/` and are accessed through `Shared.url(forResource:withExtension:)`, which wraps `Bundle.module`. Add new fixtures there, not under `Tests/`.
+
+Swift Package Manager only compiles `.swift` files inside a target's source path (`Tests/<TargetName>/...`). Loose files at `Tests/foo.swift` or the repo root are silently ignored — always place new tests inside `Tests/ImageMetadataTests/` or `Tests/imgmdTests/`.
+
+## CI
+
+`.github/workflows/swift.yml` runs `swift build` and `swift test` on `macos-latest` for pushes and PRs to `main`.

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ let package = Package(
     name: "ImageMetadata",
     defaultLocalization: "en-US",
     platforms: [
-        .macOS(.v14),
-        .iOS(.v17),
-        .watchOS(.v10),
-        .tvOS(.v17),
+        .macOS(.v15),
+        .iOS(.v18),
+        .watchOS(.v11),
+        .tvOS(.v18),
     ],
     products: [
         .library(name: "ImageMetadata", targets: ["ImageMetadata"]),

--- a/README.md
+++ b/README.md
@@ -71,17 +71,18 @@ OVERVIEW: Outputs metadata from the supplied image files as JSON.
 All metadata is output by default. Use the options to limit what metadata is
 displayed.
 
-USAGE: imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--debug] [<files> ...]
+USAGE: imgmd [<options>] [<files> ...]
 
 ARGUMENTS:
   <files>                 Image files.
 
 OPTIONS:
   -b, --basic             Basic. Don't include other metadata.
-  -e, --exif/--no-exif    Include EXIF metadata. (default: --exif)
-  -g, --gps/--no-gps      Include GPS metadata. (default: --gps)
-  -i, --iptc/--no-iptc    Include IPTC metadata. (default: --iptc)
-  -t, --tiff/--no-tiff    Include TIFF metadata. (default: --tiff)
+  -e, --exif/--no-exif    Include EXIF metadata. (default: --no-exif)
+  -g, --gps/--no-gps      Include GPS metadata. (default: --no-gps)
+  -i, --iptc/--no-iptc    Include IPTC metadata. (default: --no-iptc)
+  -t, --tiff/--no-tiff    Include TIFF metadata. (default: --no-tiff)
+  --dng/--no-dng          Include DNG metadata. (default: --no-dng)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
 

--- a/Sources/ImageMetadata/DNG/DNG+Encodable.swift
+++ b/Sources/ImageMetadata/DNG/DNG+Encodable.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+extension DNG: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case version
+        case backwardVersion
+        case uniqueCameraModel
+        case localizedCameraModel
+        case cameraSerialNumber
+        case lensInfo
+        case rawDataUniqueID
+
+        case cfaLayout
+        case cfaPlaneColor
+        case activeArea
+        case maskedAreas
+        case subTileBlockSize
+        case rowInterleaveFactor
+
+        case linearizationTable
+        case blackLevelRepeatDim
+        case blackLevel
+        case blackLevelDeltaH
+        case blackLevelDeltaV
+        case whiteLevel
+        case bayerGreenSplit
+        case linearResponseLimit
+
+        case defaultCropOrigin
+        case defaultCropSize
+        case defaultScale
+        case defaultUserCrop
+        case bestQualityScale
+        case antiAliasStrength
+        case chromaBlurRadius
+
+        case calibrationIlluminant1
+        case calibrationIlluminant2
+        case colorMatrix1
+        case colorMatrix2
+        case cameraCalibration1
+        case cameraCalibration2
+        case reductionMatrix1
+        case reductionMatrix2
+        case forwardMatrix1
+        case forwardMatrix2
+        case analogBalance
+        case asShotNeutral
+        case asShotWhiteXY
+        case cameraCalibrationSignature
+        case profileCalibrationSignature
+
+        case baselineExposure
+        case baselineExposureOffset
+        case baselineNoise
+        case baselineSharpness
+        case noiseProfile
+        case noiseReductionApplied
+        case shadowScale
+        case defaultBlackRender
+
+        case profileName
+        case profileCopyright
+        case profileEmbedPolicy
+        case asShotProfileName
+        case asShotPreProfileMatrix
+        case asShotICCProfile
+        case currentPreProfileMatrix
+        case currentICCProfile
+        case profileHueSatMapData1
+        case profileHueSatMapData2
+        case profileHueSatMapDims
+        case profileHueSatMapEncoding
+        case profileLookTableData
+        case profileLookTableDims
+        case profileLookTableEncoding
+        case profileToneCurve
+        case colorimetricReference
+        case extraCameraProfiles
+
+        case originalRawFileName
+        case originalRawFileData
+        case originalRawFileDigest
+        case originalDefaultCropSize
+        case originalDefaultFinalSize
+        case originalBestQualityFinalSize
+        case rawImageDigest
+        case newRawImageDigest
+        case rawToPreviewGain
+
+        case previewApplicationName
+        case previewApplicationVersion
+        case previewSettingsName
+        case previewSettingsDigest
+        case previewColorSpace
+        case previewDateTime
+
+        case opcodeList1
+        case opcodeList2
+        case opcodeList3
+        case warpRectilinear
+        case warpFisheye
+        case fixVignetteRadial
+
+        case makerNoteSafety
+        case privateData
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(version, forKey: .version)
+        try container.encodeIfPresent(backwardVersion, forKey: .backwardVersion)
+        try container.encodeIfPresent(uniqueCameraModel, forKey: .uniqueCameraModel)
+        try container.encodeIfPresent(localizedCameraModel, forKey: .localizedCameraModel)
+        try container.encodeIfPresent(cameraSerialNumber, forKey: .cameraSerialNumber)
+        try container.encodeIfPresent(lensInfo, forKey: .lensInfo)
+        try container.encodeIfPresent(rawDataUniqueID, forKey: .rawDataUniqueID)
+
+        try container.encodeIfPresent(cfaLayout, forKey: .cfaLayout)
+        try container.encodeIfPresent(cfaPlaneColor, forKey: .cfaPlaneColor)
+        try container.encodeIfPresent(activeArea, forKey: .activeArea)
+        try container.encodeIfPresent(maskedAreas, forKey: .maskedAreas)
+        try container.encodeIfPresent(subTileBlockSize, forKey: .subTileBlockSize)
+        try container.encodeIfPresent(rowInterleaveFactor, forKey: .rowInterleaveFactor)
+
+        try container.encodeIfPresent(linearizationTable?.count, forKey: .linearizationTable)
+        try container.encodeIfPresent(blackLevelRepeatDim, forKey: .blackLevelRepeatDim)
+        try container.encodeIfPresent(blackLevel, forKey: .blackLevel)
+        try container.encodeIfPresent(blackLevelDeltaH, forKey: .blackLevelDeltaH)
+        try container.encodeIfPresent(blackLevelDeltaV, forKey: .blackLevelDeltaV)
+        try container.encodeIfPresent(whiteLevel, forKey: .whiteLevel)
+        try container.encodeIfPresent(bayerGreenSplit, forKey: .bayerGreenSplit)
+        try container.encodeIfPresent(linearResponseLimit, forKey: .linearResponseLimit)
+
+        try container.encodeIfPresent(defaultCropOrigin, forKey: .defaultCropOrigin)
+        try container.encodeIfPresent(defaultCropSize, forKey: .defaultCropSize)
+        try container.encodeIfPresent(defaultScale, forKey: .defaultScale)
+        try container.encodeIfPresent(defaultUserCrop, forKey: .defaultUserCrop)
+        try container.encodeIfPresent(bestQualityScale, forKey: .bestQualityScale)
+        try container.encodeIfPresent(antiAliasStrength, forKey: .antiAliasStrength)
+        try container.encodeIfPresent(chromaBlurRadius, forKey: .chromaBlurRadius)
+
+        try container.encodeIfPresent(calibrationIlluminant1, forKey: .calibrationIlluminant1)
+        try container.encodeIfPresent(calibrationIlluminant2, forKey: .calibrationIlluminant2)
+        try container.encodeIfPresent(colorMatrix1, forKey: .colorMatrix1)
+        try container.encodeIfPresent(colorMatrix2, forKey: .colorMatrix2)
+        try container.encodeIfPresent(cameraCalibration1, forKey: .cameraCalibration1)
+        try container.encodeIfPresent(cameraCalibration2, forKey: .cameraCalibration2)
+        try container.encodeIfPresent(reductionMatrix1, forKey: .reductionMatrix1)
+        try container.encodeIfPresent(reductionMatrix2, forKey: .reductionMatrix2)
+        try container.encodeIfPresent(forwardMatrix1, forKey: .forwardMatrix1)
+        try container.encodeIfPresent(forwardMatrix2, forKey: .forwardMatrix2)
+        try container.encodeIfPresent(analogBalance, forKey: .analogBalance)
+        try container.encodeIfPresent(asShotNeutral, forKey: .asShotNeutral)
+        try container.encodeIfPresent(asShotWhiteXY, forKey: .asShotWhiteXY)
+        try container.encodeIfPresent(cameraCalibrationSignature, forKey: .cameraCalibrationSignature)
+        try container.encodeIfPresent(profileCalibrationSignature, forKey: .profileCalibrationSignature)
+
+        try container.encodeIfPresent(baselineExposure, forKey: .baselineExposure)
+        try container.encodeIfPresent(baselineExposureOffset, forKey: .baselineExposureOffset)
+        try container.encodeIfPresent(baselineNoise, forKey: .baselineNoise)
+        try container.encodeIfPresent(baselineSharpness, forKey: .baselineSharpness)
+        try container.encodeIfPresent(noiseProfile, forKey: .noiseProfile)
+        try container.encodeIfPresent(noiseReductionApplied, forKey: .noiseReductionApplied)
+        try container.encodeIfPresent(shadowScale, forKey: .shadowScale)
+        try container.encodeIfPresent(defaultBlackRender, forKey: .defaultBlackRender)
+
+        try container.encodeIfPresent(profileName, forKey: .profileName)
+        try container.encodeIfPresent(profileCopyright, forKey: .profileCopyright)
+        try container.encodeIfPresent(profileEmbedPolicy, forKey: .profileEmbedPolicy)
+        try container.encodeIfPresent(asShotProfileName, forKey: .asShotProfileName)
+        try container.encodeIfPresent(asShotPreProfileMatrix, forKey: .asShotPreProfileMatrix)
+        try container.encodeIfPresent(asShotICCProfile?.count, forKey: .asShotICCProfile)
+        try container.encodeIfPresent(currentPreProfileMatrix, forKey: .currentPreProfileMatrix)
+        try container.encodeIfPresent(currentICCProfile?.count, forKey: .currentICCProfile)
+        try container.encodeIfPresent(profileHueSatMapData1, forKey: .profileHueSatMapData1)
+        try container.encodeIfPresent(profileHueSatMapData2, forKey: .profileHueSatMapData2)
+        try container.encodeIfPresent(profileHueSatMapDims, forKey: .profileHueSatMapDims)
+        try container.encodeIfPresent(profileHueSatMapEncoding, forKey: .profileHueSatMapEncoding)
+        try container.encodeIfPresent(profileLookTableData, forKey: .profileLookTableData)
+        try container.encodeIfPresent(profileLookTableDims, forKey: .profileLookTableDims)
+        try container.encodeIfPresent(profileLookTableEncoding, forKey: .profileLookTableEncoding)
+        try container.encodeIfPresent(profileToneCurve, forKey: .profileToneCurve)
+        try container.encodeIfPresent(colorimetricReference, forKey: .colorimetricReference)
+        try container.encodeIfPresent(extraCameraProfiles, forKey: .extraCameraProfiles)
+
+        try container.encodeIfPresent(originalRawFileName, forKey: .originalRawFileName)
+        try container.encodeIfPresent(originalRawFileData?.count, forKey: .originalRawFileData)
+        try container.encodeIfPresent(originalRawFileDigest, forKey: .originalRawFileDigest)
+        try container.encodeIfPresent(originalDefaultCropSize, forKey: .originalDefaultCropSize)
+        try container.encodeIfPresent(originalDefaultFinalSize, forKey: .originalDefaultFinalSize)
+        try container.encodeIfPresent(originalBestQualityFinalSize, forKey: .originalBestQualityFinalSize)
+        try container.encodeIfPresent(rawImageDigest, forKey: .rawImageDigest)
+        try container.encodeIfPresent(newRawImageDigest, forKey: .newRawImageDigest)
+        try container.encodeIfPresent(rawToPreviewGain, forKey: .rawToPreviewGain)
+
+        try container.encodeIfPresent(previewApplicationName, forKey: .previewApplicationName)
+        try container.encodeIfPresent(previewApplicationVersion, forKey: .previewApplicationVersion)
+        try container.encodeIfPresent(previewSettingsName, forKey: .previewSettingsName)
+        try container.encodeIfPresent(previewSettingsDigest, forKey: .previewSettingsDigest)
+        try container.encodeIfPresent(previewColorSpace, forKey: .previewColorSpace)
+        try container.encodeIfPresent(previewDateTime, forKey: .previewDateTime)
+
+        try container.encodeIfPresent(opcodeList1?.count, forKey: .opcodeList1)
+        try container.encodeIfPresent(opcodeList2?.count, forKey: .opcodeList2)
+        try container.encodeIfPresent(opcodeList3?.count, forKey: .opcodeList3)
+        try container.encodeIfPresent(warpRectilinear, forKey: .warpRectilinear)
+        try container.encodeIfPresent(warpFisheye, forKey: .warpFisheye)
+        try container.encodeIfPresent(fixVignetteRadial, forKey: .fixVignetteRadial)
+
+        try container.encodeIfPresent(makerNoteSafety, forKey: .makerNoteSafety)
+        try container.encodeIfPresent(privateData?.count, forKey: .privateData)
+    }
+}

--- a/Sources/ImageMetadata/DNG/DNG.swift
+++ b/Sources/ImageMetadata/DNG/DNG.swift
@@ -9,11 +9,11 @@ public struct DNG: Metadata {
 
     // MARK: - Identification & versioning
 
-    /// The DNG specification version this file was written against. Four bytes (e.g. `[1, 4, 0, 0]`).
-    public let version: [Int]?
+    /// The DNG specification version this file was written against (e.g. `"1.4.0.0"`).
+    public let version: String?
 
     /// The oldest DNG specification version a reader needs to understand to render this file.
-    public let backwardVersion: [Int]?
+    public let backwardVersion: String?
 
     /// A unique, non-localized identifier for the camera model that produced this image.
     public let uniqueCameraModel: String?
@@ -308,8 +308,8 @@ public struct DNG: Metadata {
     // MARK: - Initialization
 
     public init(rawValue: NSDictionary) {
-        self.version = Self.intArray(rawValue[kCGImagePropertyDNGVersion])
-        self.backwardVersion = Self.intArray(rawValue[kCGImagePropertyDNGBackwardVersion])
+        self.version = Self.versionString(rawValue[kCGImagePropertyDNGVersion])
+        self.backwardVersion = Self.versionString(rawValue[kCGImagePropertyDNGBackwardVersion])
         self.uniqueCameraModel = rawValue[kCGImagePropertyDNGUniqueCameraModel] as? String
         self.localizedCameraModel = rawValue[kCGImagePropertyDNGLocalizedCameraModel] as? String
         self.cameraSerialNumber = rawValue[kCGImagePropertyDNGCameraSerialNumber] as? String
@@ -445,5 +445,10 @@ public struct DNG: Metadata {
     private static func describe(_ value: Any?) -> String? {
         guard let value, !(value is NSNull) else { return nil }
         return String(describing: value)
+    }
+
+    private static func versionString(_ value: Any?) -> String? {
+        guard let components = value as? [CustomStringConvertible] else { return nil }
+        return components.map { String(describing: $0) }.joined(separator: ".")
     }
 }

--- a/Sources/ImageMetadata/DNG/DNG.swift
+++ b/Sources/ImageMetadata/DNG/DNG.swift
@@ -1,0 +1,449 @@
+public import Foundation
+import ImageIO
+
+/// Digital Negative (DNG)
+///
+/// Adobe's open, lossless raw image format. The keys mirror Apple's
+/// [DNG Image Properties](https://developer.apple.com/documentation/imageio/dng-image-properties).
+public struct DNG: Metadata {
+
+    // MARK: - Identification & versioning
+
+    /// The DNG specification version this file was written against. Four bytes (e.g. `[1, 4, 0, 0]`).
+    public let version: [Int]?
+
+    /// The oldest DNG specification version a reader needs to understand to render this file.
+    public let backwardVersion: [Int]?
+
+    /// A unique, non-localized identifier for the camera model that produced this image.
+    public let uniqueCameraModel: String?
+
+    /// A localized name for the camera model.
+    public let localizedCameraModel: String?
+
+    /// The camera body's serial number.
+    public let cameraSerialNumber: String?
+
+    /// Lens info: min focal length, max focal length, min f-number at min focal length, min f-number at max focal length.
+    public let lensInfo: [Double]?
+
+    /// A unique identifier for the raw image data, independent of any subsequent metadata edits.
+    public let rawDataUniqueID: Data?
+
+    // MARK: - CFA pattern & sensor layout
+
+    /// Spatial layout of the color filter array.
+    public let cfaLayout: Int?
+
+    /// Color of each plane in a CFA image.
+    public let cfaPlaneColor: [Int]?
+
+    /// The active (non-masked) area of the sensor, as `[top, left, bottom, right]`.
+    public let activeArea: [Int]?
+
+    /// Rectangles of masked (optically black) pixels, four longs per rectangle.
+    public let maskedAreas: [Int]?
+
+    /// Block size of the smallest tile used for sub-tile decoding.
+    public let subTileBlockSize: [Int]?
+
+    /// The interleave factor of pixel rows in the raw image.
+    public let rowInterleaveFactor: Int?
+
+    // MARK: - Linearization & black/white levels
+
+    /// Lookup table mapping stored values to linear values.
+    public let linearizationTable: [Int]?
+
+    /// Repeat dimensions for the BlackLevel pattern, as `[rows, columns]`.
+    public let blackLevelRepeatDim: [Int]?
+
+    /// Per-channel black level values.
+    public let blackLevel: [Double]?
+
+    /// Per-column black level offsets.
+    public let blackLevelDeltaH: [Double]?
+
+    /// Per-row black level offsets.
+    public let blackLevelDeltaV: [Double]?
+
+    /// Maximum value in the raw image (the "white" level), per channel.
+    public let whiteLevel: [Int]?
+
+    /// Bayer green split, indicating sensitivity differences between the two greens in a Bayer pattern.
+    public let bayerGreenSplit: Int?
+
+    /// The point at which the camera's sensor response begins to clip.
+    public let linearResponseLimit: Double?
+
+    // MARK: - Default rendering geometry
+
+    /// Default crop origin in raw pixel coordinates.
+    public let defaultCropOrigin: [Double]?
+
+    /// Default crop size in raw pixel coordinates.
+    public let defaultCropSize: [Double]?
+
+    /// Default scale factor applied during rendering, `[horizontal, vertical]`.
+    public let defaultScale: [Double]?
+
+    /// Default user crop rectangle (relative to DefaultCrop), `[top, left, bottom, right]`.
+    public let defaultUserCrop: [Double]?
+
+    /// Best-quality scale factor for the image.
+    public let bestQualityScale: Double?
+
+    /// Strength of anti-aliasing filter applied by the camera.
+    public let antiAliasStrength: Double?
+
+    /// Radius (in pixels) of chroma blur applied during demosaicing.
+    public let chromaBlurRadius: Double?
+
+    // MARK: - Color calibration & profiles
+
+    /// Illuminant for ColorMatrix1 / CameraCalibration1.
+    public let calibrationIlluminant1: Int?
+
+    /// Illuminant for ColorMatrix2 / CameraCalibration2.
+    public let calibrationIlluminant2: Int?
+
+    /// Color matrix for the first calibration illuminant.
+    public let colorMatrix1: [Double]?
+
+    /// Color matrix for the second calibration illuminant.
+    public let colorMatrix2: [Double]?
+
+    /// Camera calibration matrix for the first illuminant.
+    public let cameraCalibration1: [Double]?
+
+    /// Camera calibration matrix for the second illuminant.
+    public let cameraCalibration2: [Double]?
+
+    /// Reduction matrix for the first illuminant (used to convert to a 3-channel space).
+    public let reductionMatrix1: [Double]?
+
+    /// Reduction matrix for the second illuminant.
+    public let reductionMatrix2: [Double]?
+
+    /// Forward matrix for the first illuminant (camera native to PCS).
+    public let forwardMatrix1: [Double]?
+
+    /// Forward matrix for the second illuminant.
+    public let forwardMatrix2: [Double]?
+
+    /// Analog balance applied to each channel before the camera's color matrices.
+    public let analogBalance: [Double]?
+
+    /// As-shot per-channel neutral coefficients.
+    public let asShotNeutral: [Double]?
+
+    /// As-shot white point in chromaticity (xy) coordinates.
+    public let asShotWhiteXY: [Double]?
+
+    /// Per-camera-model signature for matching CameraCalibration matrices.
+    public let cameraCalibrationSignature: String?
+
+    /// Per-camera-model signature for matching DNG profiles.
+    public let profileCalibrationSignature: String?
+
+    // MARK: - Exposure & noise
+
+    /// Baseline exposure compensation, in stops.
+    public let baselineExposure: Double?
+
+    /// Default offset to apply on top of BaselineExposure.
+    public let baselineExposureOffset: Double?
+
+    /// Baseline noise estimate.
+    public let baselineNoise: Double?
+
+    /// Baseline sharpness estimate.
+    public let baselineSharpness: Double?
+
+    /// Per-channel noise profile (variance pairs).
+    public let noiseProfile: [Double]?
+
+    /// Whether the camera applied noise reduction; non-zero means yes.
+    public let noiseReductionApplied: Double?
+
+    /// Shadow scale factor, applied to render shadows.
+    public let shadowScale: Double?
+
+    /// Default scale to apply when rendering "black" pixels in the rendered output.
+    public let defaultBlackRender: Int?
+
+    // MARK: - Profiles
+
+    /// Name of the embedded camera profile.
+    public let profileName: String?
+
+    /// Copyright string for the embedded profile.
+    public let profileCopyright: String?
+
+    /// Profile embed policy (allow/deny copying).
+    public let profileEmbedPolicy: Int?
+
+    /// As-shot profile name selected by the camera.
+    public let asShotProfileName: String?
+
+    /// As-shot pre-profile matrix (applied before the profile's color transform).
+    public let asShotPreProfileMatrix: [Double]?
+
+    /// As-shot embedded ICC profile.
+    public let asShotICCProfile: Data?
+
+    /// Currently selected pre-profile matrix.
+    public let currentPreProfileMatrix: [Double]?
+
+    /// Currently selected embedded ICC profile.
+    public let currentICCProfile: Data?
+
+    /// Hue/saturation map (illuminant 1).
+    public let profileHueSatMapData1: [Double]?
+
+    /// Hue/saturation map (illuminant 2).
+    public let profileHueSatMapData2: [Double]?
+
+    /// Hue/saturation map dimensions: `[hueDivisions, saturationDivisions, valueDivisions]`.
+    public let profileHueSatMapDims: [Int]?
+
+    /// Encoding used by the hue/saturation map (linear or sRGB).
+    public let profileHueSatMapEncoding: Int?
+
+    /// 3-D look-up table data.
+    public let profileLookTableData: [Double]?
+
+    /// 3-D look-up table dimensions.
+    public let profileLookTableDims: [Int]?
+
+    /// Encoding used by the look table.
+    public let profileLookTableEncoding: Int?
+
+    /// Tone curve applied by the profile.
+    public let profileToneCurve: [Double]?
+
+    /// Reference output color space for the rendered image (scene vs. output referred).
+    public let colorimetricReference: Int?
+
+    /// List of additional camera profiles.
+    public let extraCameraProfiles: [Int]?
+
+    // MARK: - Original raw provenance
+
+    /// Filename of the original raw file from which this DNG was derived.
+    public let originalRawFileName: String?
+
+    /// The full bytes of the original raw file (compressed).
+    public let originalRawFileData: Data?
+
+    /// Digest of the original raw file.
+    public let originalRawFileDigest: Data?
+
+    /// Default crop size used by the original raw renderer.
+    public let originalDefaultCropSize: [Double]?
+
+    /// Default final size used by the original raw renderer.
+    public let originalDefaultFinalSize: [Int]?
+
+    /// Best-quality final size used by the original raw renderer.
+    public let originalBestQualityFinalSize: [Int]?
+
+    /// Digest of the raw image data.
+    public let rawImageDigest: Data?
+
+    /// New (DNG 1.4+) digest of the raw image data.
+    public let newRawImageDigest: Data?
+
+    /// Gain factor between the raw image and its embedded preview.
+    public let rawToPreviewGain: Double?
+
+    // MARK: - Preview
+
+    /// Application that rendered the preview.
+    public let previewApplicationName: String?
+
+    /// Version of the application that rendered the preview.
+    public let previewApplicationVersion: String?
+
+    /// Name of the rendering settings used for the preview.
+    public let previewSettingsName: String?
+
+    /// Digest of the rendering settings used for the preview.
+    public let previewSettingsDigest: Data?
+
+    /// Color space of the embedded preview.
+    public let previewColorSpace: Int?
+
+    /// Date/time the preview was rendered (ISO 8601).
+    public let previewDateTime: Date?
+
+    // MARK: - Opcodes
+
+    /// Opcode list applied before the linearization step.
+    public let opcodeList1: Data?
+
+    /// Opcode list applied between linearization and demosaic.
+    public let opcodeList2: Data?
+
+    /// Opcode list applied after demosaic.
+    public let opcodeList3: Data?
+
+    /// Rectilinear lens warp opcode descriptor.
+    public let warpRectilinear: String?
+
+    /// Fisheye lens warp opcode descriptor.
+    public let warpFisheye: String?
+
+    /// Radial vignette correction opcode descriptor.
+    public let fixVignetteRadial: String?
+
+    // MARK: - Misc
+
+    /// Flag indicating whether MakerNote data is safe to copy across edits.
+    public let makerNoteSafety: Int?
+
+    /// Camera-private data block.
+    public let privateData: Data?
+
+    // MARK: - Initialization
+
+    public init(rawValue: NSDictionary) {
+        self.version = Self.intArray(rawValue[kCGImagePropertyDNGVersion])
+        self.backwardVersion = Self.intArray(rawValue[kCGImagePropertyDNGBackwardVersion])
+        self.uniqueCameraModel = rawValue[kCGImagePropertyDNGUniqueCameraModel] as? String
+        self.localizedCameraModel = rawValue[kCGImagePropertyDNGLocalizedCameraModel] as? String
+        self.cameraSerialNumber = rawValue[kCGImagePropertyDNGCameraSerialNumber] as? String
+        self.lensInfo = Self.doubleArray(rawValue[kCGImagePropertyDNGLensInfo])
+        self.rawDataUniqueID = rawValue[kCGImagePropertyDNGRawDataUniqueID] as? Data
+
+        self.cfaLayout = rawValue[kCGImagePropertyDNGCFALayout] as? Int
+        self.cfaPlaneColor = Self.intArray(rawValue[kCGImagePropertyDNGCFAPlaneColor])
+        self.activeArea = Self.intArray(rawValue[kCGImagePropertyDNGActiveArea])
+        self.maskedAreas = Self.intArray(rawValue[kCGImagePropertyDNGMaskedAreas])
+        self.subTileBlockSize = Self.intArray(rawValue[kCGImagePropertyDNGSubTileBlockSize])
+        self.rowInterleaveFactor = rawValue[kCGImagePropertyDNGRowInterleaveFactor] as? Int
+
+        self.linearizationTable = Self.intArray(rawValue[kCGImagePropertyDNGLinearizationTable])
+        self.blackLevelRepeatDim = Self.intArray(rawValue[kCGImagePropertyDNGBlackLevelRepeatDim])
+        self.blackLevel = Self.doubleArray(rawValue[kCGImagePropertyDNGBlackLevel])
+        self.blackLevelDeltaH = Self.doubleArray(rawValue[kCGImagePropertyDNGBlackLevelDeltaH])
+        self.blackLevelDeltaV = Self.doubleArray(rawValue[kCGImagePropertyDNGBlackLevelDeltaV])
+        self.whiteLevel = Self.intArray(rawValue[kCGImagePropertyDNGWhiteLevel])
+        self.bayerGreenSplit = rawValue[kCGImagePropertyDNGBayerGreenSplit] as? Int
+        self.linearResponseLimit = rawValue[kCGImagePropertyDNGLinearResponseLimit] as? Double
+
+        self.defaultCropOrigin = Self.doubleArray(rawValue[kCGImagePropertyDNGDefaultCropOrigin])
+        self.defaultCropSize = Self.doubleArray(rawValue[kCGImagePropertyDNGDefaultCropSize])
+        self.defaultScale = Self.doubleArray(rawValue[kCGImagePropertyDNGDefaultScale])
+        self.defaultUserCrop = Self.doubleArray(rawValue[kCGImagePropertyDNGDefaultUserCrop])
+        self.bestQualityScale = rawValue[kCGImagePropertyDNGBestQualityScale] as? Double
+        self.antiAliasStrength = rawValue[kCGImagePropertyDNGAntiAliasStrength] as? Double
+        self.chromaBlurRadius = rawValue[kCGImagePropertyDNGChromaBlurRadius] as? Double
+
+        self.calibrationIlluminant1 = rawValue[kCGImagePropertyDNGCalibrationIlluminant1] as? Int
+        self.calibrationIlluminant2 = rawValue[kCGImagePropertyDNGCalibrationIlluminant2] as? Int
+        self.colorMatrix1 = Self.doubleArray(rawValue[kCGImagePropertyDNGColorMatrix1])
+        self.colorMatrix2 = Self.doubleArray(rawValue[kCGImagePropertyDNGColorMatrix2])
+        self.cameraCalibration1 = Self.doubleArray(rawValue[kCGImagePropertyDNGCameraCalibration1])
+        self.cameraCalibration2 = Self.doubleArray(rawValue[kCGImagePropertyDNGCameraCalibration2])
+        self.reductionMatrix1 = Self.doubleArray(rawValue[kCGImagePropertyDNGReductionMatrix1])
+        self.reductionMatrix2 = Self.doubleArray(rawValue[kCGImagePropertyDNGReductionMatrix2])
+        self.forwardMatrix1 = Self.doubleArray(rawValue[kCGImagePropertyDNGForwardMatrix1])
+        self.forwardMatrix2 = Self.doubleArray(rawValue[kCGImagePropertyDNGForwardMatrix2])
+        self.analogBalance = Self.doubleArray(rawValue[kCGImagePropertyDNGAnalogBalance])
+        self.asShotNeutral = Self.doubleArray(rawValue[kCGImagePropertyDNGAsShotNeutral])
+        self.asShotWhiteXY = Self.doubleArray(rawValue[kCGImagePropertyDNGAsShotWhiteXY])
+        self.cameraCalibrationSignature = rawValue[kCGImagePropertyDNGCameraCalibrationSignature] as? String
+        self.profileCalibrationSignature = rawValue[kCGImagePropertyDNGProfileCalibrationSignature] as? String
+
+        self.baselineExposure = rawValue[kCGImagePropertyDNGBaselineExposure] as? Double
+        self.baselineExposureOffset = rawValue[kCGImagePropertyDNGBaselineExposureOffset] as? Double
+        self.baselineNoise = rawValue[kCGImagePropertyDNGBaselineNoise] as? Double
+        self.baselineSharpness = rawValue[kCGImagePropertyDNGBaselineSharpness] as? Double
+        self.noiseProfile = Self.doubleArray(rawValue[kCGImagePropertyDNGNoiseProfile])
+        self.noiseReductionApplied = rawValue[kCGImagePropertyDNGNoiseReductionApplied] as? Double
+        self.shadowScale = rawValue[kCGImagePropertyDNGShadowScale] as? Double
+        self.defaultBlackRender = rawValue[kCGImagePropertyDNGDefaultBlackRender] as? Int
+
+        self.profileName = rawValue[kCGImagePropertyDNGProfileName] as? String
+        self.profileCopyright = rawValue[kCGImagePropertyDNGProfileCopyright] as? String
+        self.profileEmbedPolicy = rawValue[kCGImagePropertyDNGProfileEmbedPolicy] as? Int
+        self.asShotProfileName = rawValue[kCGImagePropertyDNGAsShotProfileName] as? String
+        self.asShotPreProfileMatrix = Self.doubleArray(rawValue[kCGImagePropertyDNGAsShotPreProfileMatrix])
+        self.asShotICCProfile = rawValue[kCGImagePropertyDNGAsShotICCProfile] as? Data
+        self.currentPreProfileMatrix = Self.doubleArray(rawValue[kCGImagePropertyDNGCurrentPreProfileMatrix])
+        self.currentICCProfile = rawValue[kCGImagePropertyDNGCurrentICCProfile] as? Data
+        self.profileHueSatMapData1 = Self.doubleArray(rawValue[kCGImagePropertyDNGProfileHueSatMapData1])
+        self.profileHueSatMapData2 = Self.doubleArray(rawValue[kCGImagePropertyDNGProfileHueSatMapData2])
+        self.profileHueSatMapDims = Self.intArray(rawValue[kCGImagePropertyDNGProfileHueSatMapDims])
+        self.profileHueSatMapEncoding = rawValue[kCGImagePropertyDNGProfileHueSatMapEncoding] as? Int
+        self.profileLookTableData = Self.doubleArray(rawValue[kCGImagePropertyDNGProfileLookTableData])
+        self.profileLookTableDims = Self.intArray(rawValue[kCGImagePropertyDNGProfileLookTableDims])
+        self.profileLookTableEncoding = rawValue[kCGImagePropertyDNGProfileLookTableEncoding] as? Int
+        self.profileToneCurve = Self.doubleArray(rawValue[kCGImagePropertyDNGProfileToneCurve])
+        self.colorimetricReference = rawValue[kCGImagePropertyDNGColorimetricReference] as? Int
+        self.extraCameraProfiles = Self.intArray(rawValue[kCGImagePropertyDNGExtraCameraProfiles])
+
+        self.originalRawFileName = rawValue[kCGImagePropertyDNGOriginalRawFileName] as? String
+        self.originalRawFileData = rawValue[kCGImagePropertyDNGOriginalRawFileData] as? Data
+        self.originalRawFileDigest = rawValue[kCGImagePropertyDNGOriginalRawFileDigest] as? Data
+        self.originalDefaultCropSize = Self.doubleArray(rawValue[kCGImagePropertyDNGOriginalDefaultCropSize])
+        self.originalDefaultFinalSize = Self.intArray(rawValue[kCGImagePropertyDNGOriginalDefaultFinalSize])
+        self.originalBestQualityFinalSize = Self.intArray(rawValue[kCGImagePropertyDNGOriginalBestQualityFinalSize])
+        self.rawImageDigest = rawValue[kCGImagePropertyDNGRawImageDigest] as? Data
+        self.newRawImageDigest = rawValue[kCGImagePropertyDNGNewRawImageDigest] as? Data
+        self.rawToPreviewGain = rawValue[kCGImagePropertyDNGRawToPreviewGain] as? Double
+
+        self.previewApplicationName = rawValue[kCGImagePropertyDNGPreviewApplicationName] as? String
+        self.previewApplicationVersion = rawValue[kCGImagePropertyDNGPreviewApplicationVersion] as? String
+        self.previewSettingsName = rawValue[kCGImagePropertyDNGPreviewSettingsName] as? String
+        self.previewSettingsDigest = rawValue[kCGImagePropertyDNGPreviewSettingsDigest] as? Data
+        self.previewColorSpace = rawValue[kCGImagePropertyDNGPreviewColorSpace] as? Int
+
+        if let dateString = rawValue[kCGImagePropertyDNGPreviewDateTime] as? String {
+            if let iso = try? Date.ISO8601FormatStyle().parse(dateString) {
+                self.previewDateTime = iso
+            } else {
+                // Fallback: some writers emit the EXIF "YYYY:MM:DD HH:MM:SS" form.
+                let exifStrategy = Date.VerbatimFormatStyle(
+                    format: "\(year: .defaultDigits):\(month: .twoDigits):\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .oneBased)):\(minute: .twoDigits):\(second: .twoDigits)",
+                    locale: Locale(identifier: "en_US"),
+                    timeZone: .current,
+                    calendar: .gregorian
+                ).parseStrategy
+                self.previewDateTime = try? exifStrategy.parse(dateString)
+            }
+        } else {
+            self.previewDateTime = nil
+        }
+
+        self.opcodeList1 = rawValue[kCGImagePropertyDNGOpcodeList1] as? Data
+        self.opcodeList2 = rawValue[kCGImagePropertyDNGOpcodeList2] as? Data
+        self.opcodeList3 = rawValue[kCGImagePropertyDNGOpcodeList3] as? Data
+        self.warpRectilinear = Self.describe(rawValue[kCGImagePropertyDNGWarpRectilinear])
+        self.warpFisheye = Self.describe(rawValue[kCGImagePropertyDNGWarpFisheye])
+        self.fixVignetteRadial = Self.describe(rawValue[kCGImagePropertyDNGFixVignetteRadial])
+
+        self.makerNoteSafety = rawValue[kCGImagePropertyDNGMakerNoteSafety] as? Int
+        self.privateData = rawValue[kCGImagePropertyDNGPrivateData] as? Data
+    }
+
+    // MARK: - Helpers
+
+    private static func intArray(_ value: Any?) -> [Int]? {
+        if let arr = value as? [Int] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.intValue) }
+        return nil
+    }
+
+    private static func doubleArray(_ value: Any?) -> [Double]? {
+        if let arr = value as? [Double] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.doubleValue) }
+        return nil
+    }
+
+    private static func describe(_ value: Any?) -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        return String(describing: value)
+    }
+}

--- a/Sources/ImageMetadata/EXIF/EXIF.swift
+++ b/Sources/ImageMetadata/EXIF/EXIF.swift
@@ -500,15 +500,17 @@ public struct EXIF: Metadata {
     
     static private func timeZone(forOffset offset: String?) -> TimeZone? {
         guard let offset, !offset.isEmpty else { return nil }
-        
+
+        let isNegative = offset.hasPrefix("-")
         let components = offset.split(separator: ":").compactMap { try? Int(String($0), format: .number) }
         guard components.count >= 1, components.count <= 2 else { return nil }
-        
-        var seconds = components[0] * 60 * 60
+
+        var seconds = abs(components[0]) * 60 * 60
         if components.count == 2 {
-            seconds += components[1] * 60
+            seconds += abs(components[1]) * 60
         }
-        
+        if isNegative { seconds = -seconds }
+
         return TimeZone(secondsFromGMT: Int(seconds))
     }
 }

--- a/Sources/ImageMetadata/ImageMetadata+Encodable.swift
+++ b/Sources/ImageMetadata/ImageMetadata+Encodable.swift
@@ -20,6 +20,7 @@ extension ImageMetadata: Encodable {
         case iptc
         case tiff
         case gps
+        case dng
         case imageFile = "file"
     }
     
@@ -56,7 +57,11 @@ extension ImageMetadata: Encodable {
         if options.contains(.gps) {
             try container.encodeIfPresent(gps, forKey: .gps)
         }
-                
+
+        if options.contains(.dng) {
+            try container.encodeIfPresent(dng, forKey: .dng)
+        }
+
         if let imageFile {
             var fileContainer = encoder.container(keyedBy: ImageFile.CodingKeys.self)
             try fileContainer.encodeIfPresent(imageFile.filename, forKey: .filename)

--- a/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
+++ b/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
@@ -25,6 +25,7 @@ See <doc:Usage>.
 - ``IPTC``
 - ``TIFF``
 - ``GPS``
+- ``DNG``
 
 ### Creating an `ImageMetadata` type.
 

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -66,7 +66,10 @@ public struct ImageMetadata: Metadata {
     
     /// Metadata for an image that has Global Positioning System (GPS) information.
     public let gps: GPS?
-    
+
+    /// Metadata for an image that uses Adobe's Digital Negative (DNG) raw format.
+    public let dng: DNG?
+
     public private(set) var imageFile: ImageFile?
     
 
@@ -132,6 +135,12 @@ public struct ImageMetadata: Metadata {
             self.gps = GPS(rawValue: gpsDictionary)
         } else {
             self.gps = nil
+        }
+        
+        if options.contains(.dng), let dngDictionary = rawValue[kCGImagePropertyDNGDictionary] as? NSDictionary {
+            self.dng = DNG(rawValue: dngDictionary)
+        } else {
+            self.dng = nil
         }
         
         // Defaults that may be updated in other initializers

--- a/Sources/ImageMetadata/MetadataOptions.swift
+++ b/Sources/ImageMetadata/MetadataOptions.swift
@@ -14,8 +14,10 @@ public struct MetadataOptions: OptionSet, Sendable {
     public static let tiff = MetadataOptions(rawValue: 1 << 2)
     /// Include GPS Metadata.
     public static let gps  = MetadataOptions(rawValue: 1 << 3)
+    /// Include DNG Metadata.
+    public static let dng  = MetadataOptions(rawValue: 1 << 4)
     /// Don't include any additional metadata types.
     public static let none: MetadataOptions = []
     /// Include all known metadata types.
-    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps]
+    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng]
 }

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -53,6 +53,16 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-tiff:**
 
 *Include TIFF metadata.*
+
+
+**--dng:**
+
+*Include DNG metadata.*
+
+
+**--no-dng:**
+
+*Include DNG metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -1,9 +1,10 @@
 import Foundation
 import ArgumentParser
 import ImageMetadata
+import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps
+    case exif, iptc, tiff, gps, dng
 }
 
 fileprivate extension MetadataType {
@@ -17,6 +18,8 @@ fileprivate extension MetadataType {
             return .tiff
         case .gps:
             return .gps
+        case .dng:
+            return .dng
         }
     }
 }
@@ -46,7 +49,10 @@ struct imgmd: ParsableCommand {
     
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include TIFF metadata.")
     var tiff: Bool = false
-    
+
+    @Flag(name: .long, inversion: .prefixedNo, help: "Include DNG metadata.")
+    var dng: Bool = false
+
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
     
@@ -55,6 +61,7 @@ struct imgmd: ParsableCommand {
         completion: .file(),
         transform: {
             URL.init(fileURLWithPath: $0)
+     
         }
     )
     var files: [URL] = []
@@ -78,15 +85,20 @@ struct imgmd: ParsableCommand {
         if iptc { metadataOptions.insert(.iptc) }
         if tiff { metadataOptions.insert(.tiff) }
         if gps { metadataOptions.insert(.gps) }
-        
+        if dng { metadataOptions.insert(.dng) }
+
         if basic {
             metadataOptions = MetadataOptions.none
         } else if metadataOptions.isEmpty {
             metadataOptions = MetadataOptions.all
         }
-        
-        let imagesMetadata = try files.map {
-            try ImageMetadata(url: $0, options: metadataOptions)
+
+        let imagesMetadata = try files.map { url -> ImageMetadata in
+            var options = metadataOptions
+            if !basic, Self.isDNG(url: url) {
+                options.insert(.dng)
+            }
+            return try ImageMetadata(url: url, options: options)
         }
         
         guard !imagesMetadata.isEmpty else { return }
@@ -104,5 +116,13 @@ struct imgmd: ParsableCommand {
         }
         
         print(String(decoding: json, as: UTF8.self))
+    }
+
+    private static func isDNG(url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.contentTypeKey]),
+              let type = values.contentType else {
+            return false
+        }
+        return type.conforms(to: .dng)
     }
 }

--- a/Tests/ImageMetadataTests/CalendarTests.swift
+++ b/Tests/ImageMetadataTests/CalendarTests.swift
@@ -1,0 +1,346 @@
+import Testing
+import Foundation
+@testable import ImageMetadata
+
+@Suite("Calendar Extension Tests")
+struct CalendarTests {
+
+    let referenceDate: Date
+
+    init() throws {
+        // Fixed reference instant: 2026-02-13 12:00:00 UTC.
+        var utcCalendar = Calendar.gregorian
+        utcCalendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        referenceDate = try #require(
+            DateComponents(
+                calendar: utcCalendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2026, month: 2, day: 13,
+                hour: 12, minute: 0, second: 0
+            ).date
+        )
+    }
+
+    // MARK: - Gregorian Calendar Tests
+
+    @Test("Gregorian calendar has correct identifier")
+    func gregorianCalendarIdentifier() {
+        #expect(Calendar.gregorian.identifier == .gregorian)
+    }
+
+    // MARK: - Time Zone Setting Tests
+    //
+    // `Calendar.date(bySettingTimeZone:of:)` shifts the underlying instant so
+    // that when viewed in the destination time zone, the wall-clock components
+    // match those of the original date when viewed in the source zone.
+
+    @Test("Setting EST on a UTC date preserves wall-clock components in EST")
+    func convertUTCToEST() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let est = try #require(TimeZone(identifier: "America/New_York"))
+        let converted = try #require(calendar.date(bySettingTimeZone: est, of: referenceDate))
+
+        var estCalendar = Calendar.gregorian
+        estCalendar.timeZone = est
+        let components = estCalendar.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: converted
+        )
+
+        #expect(components.year == 2026)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 12)
+        #expect(components.minute == 0)
+    }
+
+    @Test("Setting JST on a PST date preserves wall-clock components in JST")
+    func convertPSTToJST() throws {
+        var calendar = Calendar.gregorian
+        let pst = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        calendar.timeZone = pst
+
+        let pstDate = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: pst,
+                year: 2026, month: 2, day: 13,
+                hour: 9, minute: 30, second: 0
+            ).date
+        )
+
+        let jst = try #require(TimeZone(identifier: "Asia/Tokyo"))
+        let converted = try #require(calendar.date(bySettingTimeZone: jst, of: pstDate))
+
+        var jstCalendar = Calendar.gregorian
+        jstCalendar.timeZone = jst
+        let components = jstCalendar.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: converted
+        )
+
+        #expect(components.year == 2026)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 9)
+        #expect(components.minute == 30)
+    }
+
+    @Test("Setting the same time zone returns the same instant")
+    func convertToSameTimeZone() throws {
+        var calendar = Calendar.gregorian
+        let utc = try #require(TimeZone(identifier: "UTC"))
+        calendar.timeZone = utc
+
+        let converted = try #require(calendar.date(bySettingTimeZone: utc, of: referenceDate))
+
+        #expect(abs(converted.timeIntervalSince(referenceDate)) < 1.0)
+    }
+
+    @Test("Setting Sydney on a late-evening UTC date preserves the day in Sydney")
+    func convertAcrossDateBoundaryForward() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let lateUtc = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2026, month: 2, day: 13,
+                hour: 23, minute: 0, second: 0
+            ).date
+        )
+
+        let sydney = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let converted = try #require(calendar.date(bySettingTimeZone: sydney, of: lateUtc))
+
+        var sydneyCalendar = Calendar.gregorian
+        sydneyCalendar.timeZone = sydney
+        let components = sydneyCalendar.dateComponents(
+            [.year, .month, .day, .hour],
+            from: converted
+        )
+
+        #expect(components.year == 2026)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 23)
+    }
+
+    @Test("Setting Hawaii on an early-morning UTC date preserves the day in Hawaii")
+    func convertAcrossDateBoundaryBackward() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let earlyUtc = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2026, month: 2, day: 13,
+                hour: 2, minute: 0, second: 0
+            ).date
+        )
+
+        let hawaii = try #require(TimeZone(identifier: "Pacific/Honolulu"))
+        let converted = try #require(calendar.date(bySettingTimeZone: hawaii, of: earlyUtc))
+
+        var hawaiiCalendar = Calendar.gregorian
+        hawaiiCalendar.timeZone = hawaii
+        let components = hawaiiCalendar.dateComponents(
+            [.year, .month, .day, .hour],
+            from: converted
+        )
+
+        #expect(components.year == 2026)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 2)
+    }
+
+    @Test("Fractional seconds are preserved across time-zone setting")
+    func convertDateWithFractionalSeconds() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let utcDate = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2026, month: 2, day: 13,
+                hour: 12, minute: 30, second: 45,
+                nanosecond: 500_000_000
+            ).date
+        )
+
+        let gmtPlusOne = try #require(TimeZone(secondsFromGMT: 3600))
+        let converted = try #require(calendar.date(bySettingTimeZone: gmtPlusOne, of: utcDate))
+
+        var convertedCalendar = Calendar.gregorian
+        convertedCalendar.timeZone = gmtPlusOne
+        let components = convertedCalendar.dateComponents([.nanosecond], from: converted)
+        let nanosecond = try #require(components.nanosecond)
+
+        #expect(abs(nanosecond - 500_000_000) < 1_000_000)
+    }
+
+    @Test("Setting NY on a UTC date in DST uses the EDT offset (-4h)")
+    func convertUTCToNYDuringDST() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        // March 9, 2026 — past the US DST start (March 8), so NY is on EDT (-4h).
+        let utcDate = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2026, month: 3, day: 9,
+                hour: 10, minute: 0, second: 0
+            ).date
+        )
+
+        let ny = try #require(TimeZone(identifier: "America/New_York"))
+        let converted = try #require(calendar.date(bySettingTimeZone: ny, of: utcDate))
+
+        // source(0) - target(-4h) = +4h
+        let expected: TimeInterval = 4 * 3600
+        #expect(abs(converted.timeIntervalSince(utcDate) - expected) < 1.0)
+    }
+
+    @Test("Setting EST on the epoch shifts the instant later by 5h")
+    func convertEpochDate() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let epoch = Date(timeIntervalSince1970: 0)
+        let est = try #require(TimeZone(identifier: "America/New_York"))
+        let converted = try #require(calendar.date(bySettingTimeZone: est, of: epoch))
+
+        // EST has been UTC-5 since long before 1970; source(0) - target(-5h) = +5h.
+        let expected: TimeInterval = 5 * 3600
+        #expect(abs(converted.timeIntervalSince(epoch) - expected) < 1.0)
+    }
+
+    @Test("Historical dates preserve wall-clock components across zone setting")
+    func convertVeryOldDate() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let oldDate = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 1826, month: 6, day: 1,
+                hour: 12, minute: 0, second: 0
+            ).date
+        )
+
+        let paris = try #require(TimeZone(identifier: "Europe/Paris"))
+        let converted = try #require(calendar.date(bySettingTimeZone: paris, of: oldDate))
+
+        var parisCalendar = Calendar.gregorian
+        parisCalendar.timeZone = paris
+        let components = parisCalendar.dateComponents([.year, .month, .day, .hour], from: converted)
+
+        #expect(components.year == 1826)
+        #expect(components.month == 6)
+        #expect(components.day == 1)
+        #expect(components.hour == 12)
+    }
+
+    @Test("Future dates preserve wall-clock components across zone setting")
+    func convertFutureDate() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let futureDate = try #require(
+            DateComponents(
+                calendar: calendar,
+                timeZone: TimeZone(identifier: "UTC"),
+                year: 2100, month: 12, day: 31,
+                hour: 23, minute: 59, second: 59
+            ).date
+        )
+
+        let sydney = try #require(TimeZone(identifier: "Australia/Sydney"))
+        let converted = try #require(calendar.date(bySettingTimeZone: sydney, of: futureDate))
+
+        var sydneyCalendar = Calendar.gregorian
+        sydneyCalendar.timeZone = sydney
+        let components = sydneyCalendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: converted
+        )
+
+        #expect(components.year == 2100)
+        #expect(components.month == 12)
+        #expect(components.day == 31)
+        #expect(components.hour == 23)
+        #expect(components.minute == 59)
+        #expect(components.second == 59)
+    }
+
+    @Test("Setting +5:30 on a UTC date shifts the instant earlier by 5.5h")
+    func convertWithCustomTimeZoneOffset() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let custom = try #require(TimeZone(secondsFromGMT: 5 * 3600 + 30 * 60))
+        let converted = try #require(calendar.date(bySettingTimeZone: custom, of: referenceDate))
+
+        // source(UTC)=0 - target(+5:30)=+19800 => instant shifts by -19800s
+        let expected = -5.5 * 3600.0
+        #expect(abs(converted.timeIntervalSince(referenceDate) - expected) < 1.0)
+    }
+
+    @Test("Setting -6:00 on a UTC date shifts the instant later by 6h")
+    func convertWithNegativeTimeZoneOffset() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let custom = try #require(TimeZone(secondsFromGMT: -6 * 3600))
+        let converted = try #require(calendar.date(bySettingTimeZone: custom, of: referenceDate))
+
+        // source(UTC)=0 - target(-6h)=-21600 => instant shifts by +21600s
+        let expected = 6.0 * 3600.0
+        #expect(abs(converted.timeIntervalSince(referenceDate) - expected) < 1.0)
+    }
+
+    @Test("UTC -> EST -> PST -> JST -> UTC round-trip is exact")
+    func multipleConsecutiveConversions() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let est = try #require(TimeZone(identifier: "America/New_York"))
+        let date1 = try #require(calendar.date(bySettingTimeZone: est, of: referenceDate))
+
+        calendar.timeZone = est
+        let pst = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let date2 = try #require(calendar.date(bySettingTimeZone: pst, of: date1))
+
+        calendar.timeZone = pst
+        let jst = try #require(TimeZone(identifier: "Asia/Tokyo"))
+        let date3 = try #require(calendar.date(bySettingTimeZone: jst, of: date2))
+
+        calendar.timeZone = jst
+        let utc = try #require(TimeZone(identifier: "UTC"))
+        let final = try #require(calendar.date(bySettingTimeZone: utc, of: date3))
+
+        #expect(abs(final.timeIntervalSince(referenceDate)) < 1.0)
+    }
+
+    @Test("Calendar locale does not affect time-zone setting")
+    func convertWithDifferentLocale() throws {
+        var calendar = Calendar.gregorian
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        calendar.locale = Locale(identifier: "ja_JP")
+
+        let jst = try #require(TimeZone(identifier: "Asia/Tokyo"))
+        let converted = try #require(calendar.date(bySettingTimeZone: jst, of: referenceDate))
+
+        // source(UTC)=0 - target(+9h)=+32400 => instant shifts by -32400s
+        let expected = -9.0 * 3600.0
+        #expect(abs(converted.timeIntervalSince(referenceDate) - expected) < 1.0)
+    }
+}

--- a/Tests/ImageMetadataTests/DNGTests.swift
+++ b/Tests/ImageMetadataTests/DNGTests.swift
@@ -1,0 +1,492 @@
+import Testing
+import Foundation
+import ImageIO
+@testable import ImageMetadata
+
+
+struct DNGTests {
+    static func sampleRawDNG() -> NSDictionary {
+        return [
+            // Identification & versioning
+            kCGImagePropertyDNGVersion: [1, 4, 0, 0],
+            kCGImagePropertyDNGBackwardVersion: [1, 1, 0, 0],
+            kCGImagePropertyDNGUniqueCameraModel: "Canon EOS 5D Mark IV",
+            kCGImagePropertyDNGLocalizedCameraModel: "Canon EOS 5D Mark IV",
+            kCGImagePropertyDNGCameraSerialNumber: "0123456789",
+            kCGImagePropertyDNGLensInfo: [24.0, 70.0, 2.8, 2.8],
+            kCGImagePropertyDNGRawDataUniqueID: Data(repeating: 0xAB, count: 16),
+
+            // CFA / sensor layout
+            kCGImagePropertyDNGCFALayout: 1,
+            kCGImagePropertyDNGCFAPlaneColor: [0, 1, 2],
+            kCGImagePropertyDNGActiveArea: [0, 0, 4000, 6000],
+            kCGImagePropertyDNGMaskedAreas: [0, 0, 8, 6000],
+            kCGImagePropertyDNGSubTileBlockSize: [256, 256],
+            kCGImagePropertyDNGRowInterleaveFactor: 2,
+
+            // Linearization & black/white
+            kCGImagePropertyDNGLinearizationTable: Array(0..<512),
+            kCGImagePropertyDNGBlackLevelRepeatDim: [2, 2],
+            kCGImagePropertyDNGBlackLevel: [128.0, 128.0, 128.0, 128.0],
+            kCGImagePropertyDNGBlackLevelDeltaH: [0.0, 0.0, 0.0, 0.0],
+            kCGImagePropertyDNGBlackLevelDeltaV: [0.0, 0.0, 0.0, 0.0],
+            kCGImagePropertyDNGWhiteLevel: [16383, 16383, 16383],
+            kCGImagePropertyDNGBayerGreenSplit: 0,
+            kCGImagePropertyDNGLinearResponseLimit: 1.0,
+
+            // Default rendering geometry
+            kCGImagePropertyDNGDefaultCropOrigin: [0.0, 0.0],
+            kCGImagePropertyDNGDefaultCropSize: [6000.0, 4000.0],
+            kCGImagePropertyDNGDefaultScale: [1.0, 1.0],
+            kCGImagePropertyDNGDefaultUserCrop: [0.0, 0.0, 1.0, 1.0],
+            kCGImagePropertyDNGBestQualityScale: 1.0,
+            kCGImagePropertyDNGAntiAliasStrength: 1.0,
+            kCGImagePropertyDNGChromaBlurRadius: 0.0,
+
+            // Color calibration
+            kCGImagePropertyDNGCalibrationIlluminant1: 17,
+            kCGImagePropertyDNGCalibrationIlluminant2: 21,
+            kCGImagePropertyDNGColorMatrix1: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGColorMatrix2: [0.9, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 0.9],
+            kCGImagePropertyDNGCameraCalibration1: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGCameraCalibration2: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGReductionMatrix1: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGReductionMatrix2: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGForwardMatrix1: [0.5, 0.3, 0.1, 0.2, 0.7, 0.1, 0.0, 0.0, 0.8],
+            kCGImagePropertyDNGForwardMatrix2: [0.5, 0.3, 0.1, 0.2, 0.7, 0.1, 0.0, 0.0, 0.8],
+            kCGImagePropertyDNGAnalogBalance: [1.0, 1.0, 1.0],
+            kCGImagePropertyDNGAsShotNeutral: [0.5, 1.0, 0.7],
+            kCGImagePropertyDNGAsShotWhiteXY: [0.3127, 0.329],
+            kCGImagePropertyDNGCameraCalibrationSignature: "com.example.calibration",
+            kCGImagePropertyDNGProfileCalibrationSignature: "com.example.profile",
+
+            // Exposure & noise
+            kCGImagePropertyDNGBaselineExposure: 0.25,
+            kCGImagePropertyDNGBaselineExposureOffset: 0.0,
+            kCGImagePropertyDNGBaselineNoise: 1.0,
+            kCGImagePropertyDNGBaselineSharpness: 1.0,
+            kCGImagePropertyDNGNoiseProfile: [0.0001, 0.000001],
+            kCGImagePropertyDNGNoiseReductionApplied: 0.0,
+            kCGImagePropertyDNGShadowScale: 1.0,
+            kCGImagePropertyDNGDefaultBlackRender: 0,
+
+            // Profiles
+            kCGImagePropertyDNGProfileName: "Adobe Standard",
+            kCGImagePropertyDNGProfileCopyright: "© 2025 Example",
+            kCGImagePropertyDNGProfileEmbedPolicy: 1,
+            kCGImagePropertyDNGAsShotProfileName: "Adobe Standard",
+            kCGImagePropertyDNGAsShotPreProfileMatrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGAsShotICCProfile: Data(repeating: 0x01, count: 3144),
+            kCGImagePropertyDNGCurrentPreProfileMatrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            kCGImagePropertyDNGCurrentICCProfile: Data(repeating: 0x02, count: 3144),
+            kCGImagePropertyDNGProfileHueSatMapData1: [0.0, 1.0, 1.0, 0.0, 1.0, 1.0],
+            kCGImagePropertyDNGProfileHueSatMapData2: [0.0, 1.0, 1.0, 0.0, 1.0, 1.0],
+            kCGImagePropertyDNGProfileHueSatMapDims: [90, 30, 1],
+            kCGImagePropertyDNGProfileHueSatMapEncoding: 0,
+            kCGImagePropertyDNGProfileLookTableData: [0.0, 1.0, 1.0, 0.0, 1.0, 1.0],
+            kCGImagePropertyDNGProfileLookTableDims: [90, 30, 1],
+            kCGImagePropertyDNGProfileLookTableEncoding: 0,
+            kCGImagePropertyDNGProfileToneCurve: [0.0, 0.0, 1.0, 1.0],
+            kCGImagePropertyDNGColorimetricReference: 0,
+            kCGImagePropertyDNGExtraCameraProfiles: [12345, 67890],
+
+            // Original raw provenance
+            kCGImagePropertyDNGOriginalRawFileName: "IMG_0001.CR2",
+            kCGImagePropertyDNGOriginalRawFileData: Data(repeating: 0xFF, count: 1_048_576),
+            kCGImagePropertyDNGOriginalRawFileDigest: Data(repeating: 0xCD, count: 16),
+            kCGImagePropertyDNGOriginalDefaultCropSize: [6000.0, 4000.0],
+            kCGImagePropertyDNGOriginalDefaultFinalSize: [6000, 4000],
+            kCGImagePropertyDNGOriginalBestQualityFinalSize: [6000, 4000],
+            kCGImagePropertyDNGRawImageDigest: Data(repeating: 0xEF, count: 16),
+            kCGImagePropertyDNGNewRawImageDigest: Data(repeating: 0x12, count: 16),
+            kCGImagePropertyDNGRawToPreviewGain: 1.0,
+
+            // Preview
+            kCGImagePropertyDNGPreviewApplicationName: "Adobe DNG Converter",
+            kCGImagePropertyDNGPreviewApplicationVersion: "16.0",
+            kCGImagePropertyDNGPreviewSettingsName: "Default",
+            kCGImagePropertyDNGPreviewSettingsDigest: Data(repeating: 0x99, count: 16),
+            kCGImagePropertyDNGPreviewColorSpace: 2,
+            kCGImagePropertyDNGPreviewDateTime: "2025-02-13T15:34:57Z",
+
+            // Opcodes
+            kCGImagePropertyDNGOpcodeList1: Data(repeating: 0xA1, count: 256),
+            kCGImagePropertyDNGOpcodeList2: Data(repeating: 0xA2, count: 512),
+            kCGImagePropertyDNGOpcodeList3: Data(repeating: 0xA3, count: 1024),
+            kCGImagePropertyDNGWarpRectilinear: ["k0": 1.0],
+            kCGImagePropertyDNGWarpFisheye: ["k0": 0.5],
+            kCGImagePropertyDNGFixVignetteRadial: ["k0": 0.1],
+
+            // Misc
+            kCGImagePropertyDNGMakerNoteSafety: 1,
+            kCGImagePropertyDNGPrivateData: Data(repeating: 0x55, count: 4096),
+        ]
+    }
+
+    let dng: DNG
+
+    init() {
+        self.dng = DNG(rawValue: Self.sampleRawDNG())
+    }
+
+    // MARK: - Identification
+
+    @Test func version() {
+        #expect(dng.version == [1, 4, 0, 0])
+    }
+
+    @Test func backwardVersion() {
+        #expect(dng.backwardVersion == [1, 1, 0, 0])
+    }
+
+    @Test func uniqueCameraModel() {
+        #expect(dng.uniqueCameraModel == "Canon EOS 5D Mark IV")
+    }
+
+    @Test func localizedCameraModel() {
+        #expect(dng.localizedCameraModel == "Canon EOS 5D Mark IV")
+    }
+
+    @Test func cameraSerialNumber() {
+        #expect(dng.cameraSerialNumber == "0123456789")
+    }
+
+    @Test func lensInfo() {
+        #expect(dng.lensInfo == [24.0, 70.0, 2.8, 2.8])
+    }
+
+    @Test func rawDataUniqueID() {
+        #expect(dng.rawDataUniqueID?.count == 16)
+    }
+
+    // MARK: - CFA / sensor
+
+    @Test func cfaLayout() {
+        #expect(dng.cfaLayout == 1)
+    }
+
+    @Test func cfaPlaneColor() {
+        #expect(dng.cfaPlaneColor == [0, 1, 2])
+    }
+
+    @Test func activeArea() {
+        #expect(dng.activeArea == [0, 0, 4000, 6000])
+    }
+
+    @Test func maskedAreas() {
+        #expect(dng.maskedAreas == [0, 0, 8, 6000])
+    }
+
+    @Test func subTileBlockSize() {
+        #expect(dng.subTileBlockSize == [256, 256])
+    }
+
+    @Test func rowInterleaveFactor() {
+        #expect(dng.rowInterleaveFactor == 2)
+    }
+
+    // MARK: - Levels
+
+    @Test func linearizationTable() {
+        #expect(dng.linearizationTable?.count == 512)
+        #expect(dng.linearizationTable?.first == 0)
+        #expect(dng.linearizationTable?.last == 511)
+    }
+
+    @Test func blackLevelRepeatDim() {
+        #expect(dng.blackLevelRepeatDim == [2, 2])
+    }
+
+    @Test func blackLevel() {
+        #expect(dng.blackLevel == [128.0, 128.0, 128.0, 128.0])
+    }
+
+    @Test func whiteLevel() {
+        #expect(dng.whiteLevel == [16383, 16383, 16383])
+    }
+
+    @Test func bayerGreenSplit() {
+        #expect(dng.bayerGreenSplit == 0)
+    }
+
+    @Test func linearResponseLimit() {
+        #expect(dng.linearResponseLimit == 1.0)
+    }
+
+    // MARK: - Geometry
+
+    @Test func defaultCropOrigin() {
+        #expect(dng.defaultCropOrigin == [0.0, 0.0])
+    }
+
+    @Test func defaultCropSize() {
+        #expect(dng.defaultCropSize == [6000.0, 4000.0])
+    }
+
+    @Test func defaultScale() {
+        #expect(dng.defaultScale == [1.0, 1.0])
+    }
+
+    @Test func defaultUserCrop() {
+        #expect(dng.defaultUserCrop == [0.0, 0.0, 1.0, 1.0])
+    }
+
+    @Test func bestQualityScale() {
+        #expect(dng.bestQualityScale == 1.0)
+    }
+
+    // MARK: - Color calibration
+
+    @Test func calibrationIlluminants() {
+        #expect(dng.calibrationIlluminant1 == 17)
+        #expect(dng.calibrationIlluminant2 == 21)
+    }
+
+    @Test func colorMatrices() {
+        #expect(dng.colorMatrix1?.count == 9)
+        #expect(dng.colorMatrix2?.count == 9)
+    }
+
+    @Test func forwardMatrices() {
+        #expect(dng.forwardMatrix1 == [0.5, 0.3, 0.1, 0.2, 0.7, 0.1, 0.0, 0.0, 0.8])
+        #expect(dng.forwardMatrix2 == [0.5, 0.3, 0.1, 0.2, 0.7, 0.1, 0.0, 0.0, 0.8])
+    }
+
+    @Test func asShotNeutral() {
+        #expect(dng.asShotNeutral == [0.5, 1.0, 0.7])
+    }
+
+    @Test func asShotWhiteXY() {
+        #expect(dng.asShotWhiteXY == [0.3127, 0.329])
+    }
+
+    @Test func calibrationSignatures() {
+        #expect(dng.cameraCalibrationSignature == "com.example.calibration")
+        #expect(dng.profileCalibrationSignature == "com.example.profile")
+    }
+
+    // MARK: - Exposure & noise
+
+    @Test func baselineExposure() {
+        #expect(dng.baselineExposure == 0.25)
+        #expect(dng.baselineExposureOffset == 0.0)
+        #expect(dng.baselineNoise == 1.0)
+        #expect(dng.baselineSharpness == 1.0)
+    }
+
+    @Test func noiseProfile() {
+        #expect(dng.noiseProfile == [0.0001, 0.000001])
+    }
+
+    // MARK: - Profiles
+
+    @Test func profileName() {
+        #expect(dng.profileName == "Adobe Standard")
+    }
+
+    @Test func profileCopyright() {
+        #expect(dng.profileCopyright == "© 2025 Example")
+    }
+
+    @Test func profileEmbedPolicy() {
+        #expect(dng.profileEmbedPolicy == 1)
+    }
+
+    @Test func iccProfiles() {
+        #expect(dng.asShotICCProfile?.count == 3144)
+        #expect(dng.currentICCProfile?.count == 3144)
+    }
+
+    @Test func hueSatMaps() {
+        #expect(dng.profileHueSatMapDims == [90, 30, 1])
+        #expect(dng.profileHueSatMapData1?.count == 6)
+        #expect(dng.profileHueSatMapData2?.count == 6)
+        #expect(dng.profileHueSatMapEncoding == 0)
+    }
+
+    @Test func lookTable() {
+        #expect(dng.profileLookTableDims == [90, 30, 1])
+        #expect(dng.profileLookTableData?.count == 6)
+        #expect(dng.profileLookTableEncoding == 0)
+    }
+
+    @Test func toneCurve() {
+        #expect(dng.profileToneCurve == [0.0, 0.0, 1.0, 1.0])
+    }
+
+    @Test func colorimetricReference() {
+        #expect(dng.colorimetricReference == 0)
+    }
+
+    @Test func extraCameraProfiles() {
+        #expect(dng.extraCameraProfiles == [12345, 67890])
+    }
+
+    // MARK: - Original raw
+
+    @Test func originalRawFileName() {
+        #expect(dng.originalRawFileName == "IMG_0001.CR2")
+    }
+
+    @Test func originalRawFileData() {
+        #expect(dng.originalRawFileData?.count == 1_048_576)
+    }
+
+    @Test func rawDigests() {
+        #expect(dng.rawImageDigest?.count == 16)
+        #expect(dng.newRawImageDigest?.count == 16)
+        #expect(dng.originalRawFileDigest?.count == 16)
+    }
+
+    @Test func rawToPreviewGain() {
+        #expect(dng.rawToPreviewGain == 1.0)
+    }
+
+    // MARK: - Preview
+
+    @Test func previewApplication() {
+        #expect(dng.previewApplicationName == "Adobe DNG Converter")
+        #expect(dng.previewApplicationVersion == "16.0")
+        #expect(dng.previewSettingsName == "Default")
+        #expect(dng.previewSettingsDigest?.count == 16)
+        #expect(dng.previewColorSpace == 2)
+    }
+
+    @Test func previewDateTimeISO8601() throws {
+        let date = try #require(dng.previewDateTime)
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: TimeZone(identifier: "UTC")!,
+            from: date
+        )
+        #expect(components.year == 2025)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 15)
+        #expect(components.minute == 34)
+        #expect(components.second == 57)
+    }
+
+    @Test("previewDateTime falls back to EXIF YYYY:MM:DD HH:MM:SS form")
+    func previewDateTimeExifFallback() throws {
+        let raw = Self.sampleRawDNG().mutableCopy() as! NSMutableDictionary
+        raw[kCGImagePropertyDNGPreviewDateTime] = "2025:02:13 15:34:57"
+
+        let dng = DNG(rawValue: raw)
+        let date = try #require(dng.previewDateTime)
+
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            [.timeZone, .year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        #expect(components.timeZone == .current)
+        #expect(components.year == 2025)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 15)
+        #expect(components.minute == 34)
+        #expect(components.second == 57)
+    }
+
+    // MARK: - Opcodes
+
+    @Test func opcodeLists() {
+        #expect(dng.opcodeList1?.count == 256)
+        #expect(dng.opcodeList2?.count == 512)
+        #expect(dng.opcodeList3?.count == 1024)
+    }
+
+    @Test func warpAndVignette() throws {
+        let warpRect = try #require(dng.warpRectilinear)
+        #expect(warpRect.contains("k0"))
+        #expect(dng.warpFisheye != nil)
+        #expect(dng.fixVignetteRadial != nil)
+    }
+
+    // MARK: - Misc
+
+    @Test func makerNoteSafety() {
+        #expect(dng.makerNoteSafety == 1)
+    }
+
+    @Test func privateData() {
+        #expect(dng.privateData?.count == 4096)
+    }
+
+    // MARK: - Encoding
+
+    @Test("Encoding emits byte counts for binary blobs and entry count for linearization table")
+    func encodingByteCounts() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let data = try encoder.encode(dng)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        // Replaced with byte/entry counts.
+        #expect(json["asShotICCProfile"] as? Int == 3144)
+        #expect(json["currentICCProfile"] as? Int == 3144)
+        #expect(json["originalRawFileData"] as? Int == 1_048_576)
+        #expect(json["privateData"] as? Int == 4096)
+        #expect(json["opcodeList1"] as? Int == 256)
+        #expect(json["opcodeList2"] as? Int == 512)
+        #expect(json["opcodeList3"] as? Int == 1024)
+        #expect(json["linearizationTable"] as? Int == 512)
+
+        // Small digests stay as base64-encoded strings.
+        #expect(json["rawImageDigest"] is String)
+        #expect(json["newRawImageDigest"] is String)
+        #expect(json["originalRawFileDigest"] is String)
+        #expect(json["rawDataUniqueID"] is String)
+        #expect(json["previewSettingsDigest"] is String)
+    }
+
+    @Test("Encoding round-trips representative scalar and array fields")
+    func encodingScalarsAndArrays() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let data = try encoder.encode(dng)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["uniqueCameraModel"] as? String == "Canon EOS 5D Mark IV")
+        #expect(json["baselineExposure"] as? Double == 0.25)
+        #expect(json["calibrationIlluminant1"] as? Int == 17)
+        #expect(json["lensInfo"] as? [Double] == [24.0, 70.0, 2.8, 2.8])
+        #expect(json["version"] as? [Int] == [1, 4, 0, 0])
+
+        let previewDate = try #require(json["previewDateTime"] as? String)
+        #expect(previewDate.hasPrefix("2025-02-13T15:34:57"))
+    }
+
+    @Test("Missing or malformed values produce nils")
+    func missingOrMalformedValues() {
+        let raw = Self.sampleRawDNG().mutableCopy() as! NSMutableDictionary
+        raw[kCGImagePropertyDNGBaselineExposure] = "not-a-double"
+        raw[kCGImagePropertyDNGBayerGreenSplit] = NSNull()
+        raw[kCGImagePropertyDNGPreviewDateTime] = "garbage"
+        raw.removeObject(forKey: kCGImagePropertyDNGUniqueCameraModel)
+        raw.removeObject(forKey: kCGImagePropertyDNGAsShotNeutral)
+
+        let dng = DNG(rawValue: raw)
+
+        #expect(dng.baselineExposure == nil)
+        #expect(dng.bayerGreenSplit == nil)
+        #expect(dng.previewDateTime == nil)
+        #expect(dng.uniqueCameraModel == nil)
+        #expect(dng.asShotNeutral == nil)
+    }
+
+    @Test("Empty dictionary produces an all-nil DNG that encodes to {}")
+    func emptyDictionary() throws {
+        let dng = DNG(rawValue: [:])
+
+        #expect(dng.uniqueCameraModel == nil)
+        #expect(dng.colorMatrix1 == nil)
+        #expect(dng.previewDateTime == nil)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(dng)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json.isEmpty)
+    }
+}

--- a/Tests/ImageMetadataTests/DNGTests.swift
+++ b/Tests/ImageMetadataTests/DNGTests.swift
@@ -132,11 +132,11 @@ struct DNGTests {
     // MARK: - Identification
 
     @Test func version() {
-        #expect(dng.version == [1, 4, 0, 0])
+        #expect(dng.version == "1.4.0.0")
     }
 
     @Test func backwardVersion() {
-        #expect(dng.backwardVersion == [1, 1, 0, 0])
+        #expect(dng.backwardVersion == "1.1.0.0")
     }
 
     @Test func uniqueCameraModel() {
@@ -452,7 +452,7 @@ struct DNGTests {
         #expect(json["baselineExposure"] as? Double == 0.25)
         #expect(json["calibrationIlluminant1"] as? Int == 17)
         #expect(json["lensInfo"] as? [Double] == [24.0, 70.0, 2.8, 2.8])
-        #expect(json["version"] as? [Int] == [1, 4, 0, 0])
+        #expect(json["version"] as? String == "1.4.0.0")
 
         let previewDate = try #require(json["previewDateTime"] as? String)
         #expect(previewDate.hasPrefix("2025-02-13T15:34:57"))

--- a/Tests/ImageMetadataTests/EXIFTests.swift
+++ b/Tests/ImageMetadataTests/EXIFTests.swift
@@ -120,19 +120,20 @@ struct EXIFTests {
         #expect(dateComponents.hour == 8)
         #expect(dateComponents.minute == 11)
         #expect(dateComponents.second == 15)
-        #expect(dateComponents.nanosecond != nil)
-        
-        let normalizedSeconds: Double = try Double("\(dateComponents.second!).\(dateComponents.nanosecond!)", format: .number)
+
+        let second = try #require(dateComponents.second)
+        let nanosecond = try #require(dateComponents.nanosecond)
+        let normalizedSeconds: Double = try Double("\(second).\(nanosecond)", format: .number)
         #expect(normalizedSeconds.isApproximatelyEqual(to: 15.185, absoluteTolerance: 0.0000001))
     }
-    
+
     @Test func dateTimeOriginal() throws {
         let date = try #require(exif.dateTimeOriginal)
         let timeZone = try #require(exif.timeZoneOriginal)
-        
+
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
-        
+
         let dateComponents = calendar.dateComponents(
             [.timeZone, .year, .month, .day, .hour, .minute, .second, .nanosecond],
             from: date
@@ -144,9 +145,10 @@ struct EXIFTests {
         #expect(dateComponents.hour == 8)
         #expect(dateComponents.minute == 11)
         #expect(dateComponents.second == 15)
-        #expect(dateComponents.nanosecond != nil)
-        
-        let normalizedSeconds: Double = try Double("\(dateComponents.second!).\(dateComponents.nanosecond!)", format: .number)
+
+        let second = try #require(dateComponents.second)
+        let nanosecond = try #require(dateComponents.nanosecond)
+        let normalizedSeconds: Double = try Double("\(second).\(nanosecond)", format: .number)
         #expect(normalizedSeconds.isApproximatelyEqual(to: 15.185, absoluteTolerance: 0.0000001))
     }
     
@@ -439,21 +441,20 @@ struct EXIFTests {
         #expect(exif.whiteBalance == .auto)
     }
 
-    @Test func exposureTime_malformedValuesBecomeNil() throws {
-        // Malformed strings or unexpected types should not crash and should yield nil
-        let badStrings: [Any] = ["abc", "1//40", "1/", "/40", "-1/40x"]
-        for bad in badStrings {
-            let dict: NSDictionary = [ kCGImagePropertyExifExposureTime as String: bad ]
-            let exif = EXIF(rawValue: dict)
-            #expect(exif.exposureTime == nil)
-        }
+    @Test(arguments: ["abc", "1//40", "1/", "/40", "-1/40x"])
+    func exposureTime_malformedStringsBecomeNil(_ badString: String) {
+        let dict: NSDictionary = [kCGImagePropertyExifExposureTime as String: badString]
+        #expect(EXIF(rawValue: dict).exposureTime == nil)
+    }
 
-        // Unexpected container types
-        let weirds: [Any] = [["1/40"], [1, 40], ["num": "1/40"]]
-        for bad in weirds {
-            let dict: NSDictionary = [ kCGImagePropertyExifExposureTime as String: bad ]
-            let exif = EXIF(rawValue: dict)
-            #expect(exif.exposureTime == nil)
+    @Test func exposureTime_unexpectedContainersBecomeNil() {
+        let containers: [NSDictionary] = [
+            [kCGImagePropertyExifExposureTime as String: ["1/40"]],
+            [kCGImagePropertyExifExposureTime as String: [1, 40]],
+            [kCGImagePropertyExifExposureTime as String: ["num": "1/40"]]
+        ]
+        for dict in containers {
+            #expect(EXIF(rawValue: dict).exposureTime == nil)
         }
     }
 
@@ -484,9 +485,568 @@ struct EXIFTests {
         let date = try #require(exif.dateTimeOriginal)
         // We cannot assert absolute components without a timezone, but we can assert subseconds were applied
         let comps = Calendar(identifier: .gregorian).dateComponents([.second, .nanosecond], from: date)
-        #expect(comps.nanosecond != nil)
-        let normalizedSeconds: Double = try Double("\(comps.second!).\(comps.nanosecond!)", format: .number)
+        let second = try #require(comps.second)
+        let nanosecond = try #require(comps.nanosecond)
+        let normalizedSeconds: Double = try Double("\(second).\(nanosecond)", format: .number)
         #expect(abs(normalizedSeconds - 56.250) < 1e-6)
+    }
+
+    @Test func meteringMode_parsesFromStringNumberAndUnknown() {
+        // Known case by number (5 -> pattern)
+        let numDict: NSDictionary = [ kCGImagePropertyExifMeteringMode as String: 5 ]
+        #expect(EXIF(rawValue: numDict).meteringMode == .pattern)
+
+        // Unknown value
+        let unknownDict: NSDictionary = [ kCGImagePropertyExifMeteringMode as String: 123 ]
+        #expect(EXIF(rawValue: unknownDict).meteringMode == nil)
+    }
+
+    @Test func exposureMode_parsesFromStringNumberAndUnknown() {
+        // Known case by number (0 -> auto)
+        let numDict: NSDictionary = [ kCGImagePropertyExifExposureMode as String: 0 ]
+        #expect(EXIF(rawValue: numDict).exposureMode == .auto)
+
+        // Unknown value
+        let unknownDict: NSDictionary = [ kCGImagePropertyExifExposureMode as String: 99 ]
+        #expect(EXIF(rawValue: unknownDict).exposureMode == nil)
+    }
+
+    @Test func sceneCaptureType_parsesFromStringNumberAndUnknown() {
+        // Known case by number (0 -> standard)
+        let numDict: NSDictionary = [ kCGImagePropertyExifSceneCaptureType as String: 0 ]
+        #expect(EXIF(rawValue: numDict).sceneCaptureType == .standard)
+
+        // Unknown value
+        let unknownDict: NSDictionary = [ kCGImagePropertyExifSceneCaptureType as String: 77 ]
+        #expect(EXIF(rawValue: unknownDict).sceneCaptureType == nil)
+    }
+
+    @Test func compositeImage_parsesFromStringNumberAndUnknown() {
+        // Per the sample data above, raw value 1 maps to .no in this project's model.
+        let numDict: NSDictionary = [ kCGImagePropertyExifCompositeImage as String: 1 ]
+        #expect(EXIF(rawValue: numDict).compositeImage == .no)
+
+        let unknownDict: NSDictionary = [ kCGImagePropertyExifCompositeImage as String: 999 ]
+        #expect(EXIF(rawValue: unknownDict).compositeImage == nil)
+    }
+
+    // MARK: - Additional Edge Case Tests
+
+    @Test func emptyDictionary_producesAllNilProperties() {
+        let emptyDict: NSDictionary = [:]
+        let exif = EXIF(rawValue: emptyDict)
+        
+        // Sample a few key properties to ensure they're nil
+        #expect(exif.apertureValue == nil)
+        #expect(exif.bodySerialNumber == nil)
+        #expect(exif.dateTimeOriginal == nil)
+        #expect(exif.exposureTime == nil)
+        #expect(exif.fNumber == nil)
+        #expect(exif.isoSpeedRatings == nil)
+        #expect(exif.version == nil)
+    }
+
+    @Test func auxiliaryDictionary_lensModelAndSerialNumberFromAux() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifAuxDictionary as String: [
+                kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model",
+                kCGImagePropertyExifAuxLensSerialNumber as String: "AUX12345"
+            ] as NSDictionary
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.lensModel == "AUX Lens Model")
+        #expect(exif.lensSerialNumber == "AUX12345")
+    }
+
+    @Test func auxiliaryDictionary_fallbackToMainExifKeys() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifLensModel as String: "Main Lens Model",
+            kCGImagePropertyExifLensSerialNumber as String: "MAIN67890"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.lensModel == "Main Lens Model")
+        #expect(exif.lensSerialNumber == "MAIN67890")
+    }
+
+    @Test func auxiliaryDictionary_auxTakesPrecedenceOverMain() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifLensModel as String: "Main Lens Model",
+            kCGImagePropertyExifAuxDictionary as String: [
+                kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model"
+            ] as NSDictionary
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.lensModel == "AUX Lens Model")
+    }
+
+    @Test func auxiliaryDictionary_allAuxProperties() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifAuxDictionary as String: [
+                kCGImagePropertyExifAuxFirmware as String: "v1.2.3",
+                kCGImagePropertyExifAuxFlashCompensation as String: "+0.5",
+                kCGImagePropertyExifAuxImageNumber as String: "IMG_1234",
+                kCGImagePropertyExifAuxLensID as String: "LENS001",
+                kCGImagePropertyExifAuxLensInfo as String: "24-70mm f/2.8",
+                kCGImagePropertyExifAuxOwnerName as String: "John Doe",
+                kCGImagePropertyExifAuxSerialNumber as String: "SN123456"
+            ] as NSDictionary
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.firmware == "v1.2.3")
+        #expect(exif.flashCompensation == "+0.5")
+        #expect(exif.imageNumber == "IMG_1234")
+        #expect(exif.lensID == "LENS001")
+        #expect(exif.lensInfo == "24-70mm f/2.8")
+        #expect(exif.ownerName == "John Doe")
+        #expect(exif.serialNumber == "SN123456")
+    }
+
+    @Test func version_parsesSingleDigitArray() {
+        let dict: NSDictionary = [ kCGImagePropertyExifVersion as String: [2, 3, 2] ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.version == "2.3.2")
+    }
+
+    @Test func version_handlesEmptyArray() {
+        let dict: NSDictionary = [ kCGImagePropertyExifVersion as String: [] ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.version == "")
+    }
+
+    @Test func version_handlesMixedTypes() {
+        let dict: NSDictionary = [ kCGImagePropertyExifVersion as String: [2, "3", 2] ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.version == "2.3.2")
+    }
+
+    @Test func flashPixVersion_parsesTwoDigitArray() {
+        let dict: NSDictionary = [ kCGImagePropertyExifFlashPixVersion as String: [1, 0] ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.flashPixVersion == "1.0")
+    }
+
+    @Test func flashPixVersion_handlesEmptyArray() {
+        let dict: NSDictionary = [ kCGImagePropertyExifFlashPixVersion as String: [] ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.flashPixVersion == "")
+    }
+
+    @Test func dateTimeParsing_withoutTimeZone_usesGMT() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "2025:06:15 14:30:45",
+            kCGImagePropertyExifSubsecTimeOriginal as String: "500"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        let date = try #require(exif.dateTimeOriginal)
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(in: .gmt, from: date)
+        
+        #expect(components.year == 2025)
+        #expect(components.month == 6)
+        #expect(components.day == 15)
+        #expect(components.hour == 14)
+        #expect(components.minute == 30)
+    }
+
+    @Test func dateTimeParsing_withPositiveOffset() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "2025:06:15 14:30:45",
+            kCGImagePropertyExifSubsecTimeOriginal as String: "500",
+            kCGImagePropertyExifOffsetTimeOriginal as String: "+09:00"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZoneOriginal == TimeZone(secondsFromGMT: 9 * 3600))
+        #expect(exif.dateTimeOriginal != nil)
+    }
+
+    @Test func dateTimeParsing_withNegativeOffset() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeDigitized as String: "2025:06:15 14:30:45",
+            kCGImagePropertyExifSubsecTimeDigitized as String: "250",
+            kCGImagePropertyExifOffsetTimeDigitized as String: "-08:00"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZoneDigitized == TimeZone(secondsFromGMT: -8 * 3600))
+        #expect(exif.dateTimeDigitized != nil)
+    }
+
+    @Test func dateTimeParsing_withZeroSubseconds() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "2025:01:01 00:00:00",
+            kCGImagePropertyExifSubsecTimeOriginal as String: "0"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        let date = try #require(exif.dateTimeOriginal)
+        // Date was successfully unwrapped, verify it has the expected components
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(in: .gmt, from: date)
+        #expect(components.year == 2025)
+        #expect(components.month == 1)
+        #expect(components.day == 1)
+    }
+
+    @Test func dateTimeParsing_withoutSubseconds_defaultsToZero() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "2025:01:01 12:00:00"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        let date = try #require(exif.dateTimeOriginal)
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(in: .gmt, from: date)
+        
+        #expect(components.nanosecond == 0)
+    }
+
+    @Test func dateTimeParsing_malformedDateString_returnsNil() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "invalid-date"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.dateTimeOriginal == nil)
+    }
+
+    @Test func dateTimeParsing_emptyDateString_returnsNil() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: ""
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.dateTimeOriginal == nil)
+    }
+
+    @Test func timeZoneParsing_withOnlyHours() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: "+05"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == TimeZone(secondsFromGMT: 5 * 3600))
+    }
+
+    @Test func timeZoneParsing_withHoursAndMinutes() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: "+05:30"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == TimeZone(secondsFromGMT: 5 * 3600 + 30 * 60))
+    }
+
+    @Test func timeZoneParsing_withNegativeHoursAndMinutes() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: "-03:30"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == TimeZone(secondsFromGMT: -3 * 3600 - 30 * 60))
+    }
+
+    @Test func timeZoneParsing_emptyString_returnsNil() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: ""
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == nil)
+    }
+
+    @Test func timeZoneParsing_malformedString_returnsNil() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: "invalid"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == nil)
+    }
+
+    @Test func timeZoneParsing_tooManyComponents_returnsNil() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifOffsetTime as String: "+05:30:45"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.timeZone == nil)
+    }
+
+    @Test func colorSpace_sRGB() {
+        let dict: NSDictionary = [ kCGImagePropertyExifColorSpace as String: 1 ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.colorSpace == .sRGB)
+    }
+
+    @Test func colorSpace_uncalibrated() {
+        let dict: NSDictionary = [ kCGImagePropertyExifColorSpace as String: 65535 ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.colorSpace == .uncalibrated)
+    }
+
+    @Test func colorSpace_unknownValue_returnsNil() {
+        let dict: NSDictionary = [ kCGImagePropertyExifColorSpace as String: 999 ]
+        let exif = EXIF(rawValue: dict)
+        #expect(exif.colorSpace == nil)
+    }
+
+    @Test func allEnumTypes_handleUnknownRawValues() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifContrast as String: 999,
+            kCGImagePropertyExifCustomRendered as String: 999,
+            kCGImagePropertyExifLightSource as String: 999,
+            kCGImagePropertyExifSaturation as String: 999,
+            kCGImagePropertyExifSharpness as String: 999,
+            kCGImagePropertyExifSubjectDistRange as String: 999
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.contrast == nil)
+        #expect(exif.customRendered == nil)
+        #expect(exif.lightSource == nil)
+        #expect(exif.saturation == nil)
+        #expect(exif.sharpness == nil)
+        #expect(exif.subjectDistanceRange == nil)
+    }
+
+    @Test func arrayProperties_handleEmptyArrays() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifComponentsConfiguration as String: [],
+            kCGImagePropertyExifISOSpeedRatings as String: [],
+            kCGImagePropertyExifSubjectArea as String: []
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.componentsConfiguration == [])
+        #expect(exif.isoSpeedRatings == [])
+        #expect(exif.subjectArea == [])
+    }
+
+    @Test func arrayProperties_handleSingleElement() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifComponentsConfiguration as String: [1],
+            kCGImagePropertyExifISOSpeedRatings as String: [100],
+            kCGImagePropertyExifSubjectArea as String: [2000]
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.componentsConfiguration == [1])
+        #expect(exif.isoSpeedRatings == [100])
+        #expect(exif.subjectArea == [2000])
+    }
+
+    @Test func arrayProperties_handleMultipleElements() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifComponentsConfiguration as String: [1, 2, 3, 0],
+            kCGImagePropertyExifISOSpeedRatings as String: [100, 200, 400],
+            kCGImagePropertyExifSubjectArea as String: [1000, 2000, 3000, 4000]
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.componentsConfiguration == [1, 2, 3, 0])
+        #expect(exif.isoSpeedRatings == [100, 200, 400])
+        #expect(exif.subjectArea == [1000, 2000, 3000, 4000])
+    }
+
+    @Test func numericProperties_handleZeroValues() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifApertureValue as String: 0.0,
+            kCGImagePropertyExifBrightnessValue as String: 0.0,
+            kCGImagePropertyExifExposureBiasValue as String: 0.0,
+            kCGImagePropertyExifExposureTime as String: 0.0,
+            kCGImagePropertyExifFNumber as String: 0.0,
+            kCGImagePropertyExifFocalLength as String: 0.0
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.apertureValue == 0.0)
+        #expect(exif.brightnessValue == 0.0)
+        #expect(exif.exposureBiasValue == 0.0)
+        #expect(exif.exposureTime == 0.0)
+        #expect(exif.fNumber == 0.0)
+        #expect(exif.focalLength == 0.0)
+    }
+
+    @Test func numericProperties_handleNegativeValues() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifBrightnessValue as String: -2.5,
+            kCGImagePropertyExifExposureBiasValue as String: -1.0
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.brightnessValue == -2.5)
+        #expect(exif.exposureBiasValue == -1.0)
+    }
+
+    @Test func numericProperties_handleVeryLargeValues() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifPixelXDimension as String: 999999,
+            kCGImagePropertyExifPixelYDimension as String: 999999,
+            kCGImagePropertyExifFocalPlaneXResolution as String: 100000.0,
+            kCGImagePropertyExifFocalPlaneYResolution as String: 100000.0
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.pixelXDimension == 999999)
+        #expect(exif.pixelYDimension == 999999)
+        #expect(exif.focalPlaneXResolution == 100000.0)
+        #expect(exif.focalPlaneYResolution == 100000.0)
+    }
+
+    @Test func stringProperties_handleEmptyStrings() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifBodySerialNumber as String: "",
+            kCGImagePropertyExifCameraOwnerName as String: "",
+            kCGImagePropertyExifLensMake as String: "",
+            kCGImagePropertyExifLensModel as String: "",
+            kCGImagePropertyExifUserComment as String: ""
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.bodySerialNumber == "")
+        #expect(exif.cameraOwnerName == "")
+        #expect(exif.lensMake == "")
+        #expect(exif.lensModel == "")
+        #expect(exif.userComment == "")
+    }
+
+    @Test func stringProperties_handleSpecialCharacters() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifCameraOwnerName as String: "José García-Müller",
+            kCGImagePropertyExifUserComment as String: "Testing 123 !@#$%^&*()",
+            kCGImagePropertyExifLensModel as String: "Canon EF 24-70mm f/2.8L II USM"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.cameraOwnerName == "José García-Müller")
+        #expect(exif.userComment == "Testing 123 !@#$%^&*()")
+        #expect(exif.lensModel == "Canon EF 24-70mm f/2.8L II USM")
+    }
+
+    @Test func stringProperties_handleUnicode() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifCameraOwnerName as String: "田中太郎",
+            kCGImagePropertyExifUserComment as String: "🎉📷✨"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.cameraOwnerName == "田中太郎")
+        #expect(exif.userComment == "🎉📷✨")
+    }
+
+    @Test func intProperties_handleValidRanges() {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifFlash as String: 0,
+            kCGImagePropertyExifSceneType as String: 1,
+            kCGImagePropertyExifFileSource as String: 3,
+            kCGImagePropertyExifFocalLenIn35mmFilm as String: 50,
+            kCGImagePropertyExifISOSpeed as String: 6400
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.flash == 0)
+        #expect(exif.sceneType == 1)
+        #expect(exif.fileSource == 3)
+        #expect(exif.focalLenIn35mmFilm == 50)
+        #expect(exif.isoSpeed == 6400)
+    }
+
+    @Test func dateTimeDigitized_independentFromDateTimeOriginal() throws {
+        let dict: NSDictionary = [
+            kCGImagePropertyExifDateTimeOriginal as String: "2025:01:01 10:00:00",
+            kCGImagePropertyExifSubsecTimeOriginal as String: "100",
+            kCGImagePropertyExifOffsetTimeOriginal as String: "+09:00",
+            kCGImagePropertyExifDateTimeDigitized as String: "2025:01:02 11:00:00",
+            kCGImagePropertyExifSubsecTimeDigitized as String: "200",
+            kCGImagePropertyExifOffsetTimeDigitized as String: "-05:00"
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        let original = try #require(exif.dateTimeOriginal)
+        let digitized = try #require(exif.dateTimeDigitized)
+        
+        #expect(original != digitized)
+        #expect(exif.timeZoneOriginal != exif.timeZoneDigitized)
+    }
+
+    @Test(arguments: [(2, EXIF.ExposureProgram.normalProgram)])
+    func exposureProgram_allKnownValues(rawValue: Int, expected: EXIF.ExposureProgram) {
+        let dict: NSDictionary = [kCGImagePropertyExifExposureProgram as String: rawValue]
+        #expect(EXIF(rawValue: dict).exposureProgram == expected)
+    }
+
+    @Test(arguments: [(2, EXIF.SensingMethod.oneChipColorArea)])
+    func sensingMethod_allKnownValues(rawValue: Int, expected: EXIF.SensingMethod) {
+        let dict: NSDictionary = [kCGImagePropertyExifSensingMethod as String: rawValue]
+        #expect(EXIF(rawValue: dict).sensingMethod == expected)
+    }
+
+    @Test(arguments: [(0, EXIF.WhiteBalance.auto)])
+    func whiteBalance_allKnownValues(rawValue: Int, expected: EXIF.WhiteBalance) {
+        let dict: NSDictionary = [kCGImagePropertyExifWhiteBalance as String: rawValue]
+        #expect(EXIF(rawValue: dict).whiteBalance == expected)
+    }
+
+    @Test(arguments: [(0, EXIF.SceneCaptureType.standard)])
+    func sceneCaptureType_allKnownValues(rawValue: Int, expected: EXIF.SceneCaptureType) {
+        let dict: NSDictionary = [kCGImagePropertyExifSceneCaptureType as String: rawValue]
+        #expect(EXIF(rawValue: dict).sceneCaptureType == expected)
+    }
+
+    @Test(arguments: [(5, EXIF.MeteringMode.pattern)])
+    func meteringMode_allKnownValues(rawValue: Int, expected: EXIF.MeteringMode) {
+        let dict: NSDictionary = [kCGImagePropertyExifMeteringMode as String: rawValue]
+        #expect(EXIF(rawValue: dict).meteringMode == expected)
+    }
+
+    @Test(arguments: [(0, EXIF.ExposureMode.auto)])
+    func exposureMode_allKnownValues(rawValue: Int, expected: EXIF.ExposureMode) {
+        let dict: NSDictionary = [kCGImagePropertyExifExposureMode as String: rawValue]
+        #expect(EXIF(rawValue: dict).exposureMode == expected)
+    }
+
+    @Test func complexRealWorldData_parsesCorrectly() throws {
+        // Simulate a comprehensive EXIF data set from a modern camera
+        let dict: NSDictionary = [
+            kCGImagePropertyExifApertureValue as String: 2.970854,
+            kCGImagePropertyExifBrightnessValue as String: 4.5,
+            kCGImagePropertyExifColorSpace as String: 1,
+            kCGImagePropertyExifComponentsConfiguration as String: [1, 2, 3, 0],
+            kCGImagePropertyExifDateTimeOriginal as String: "2026:02:13 15:30:45",
+            kCGImagePropertyExifSubsecTimeOriginal as String: "123",
+            kCGImagePropertyExifOffsetTimeOriginal as String: "-08:00",
+            kCGImagePropertyExifExposureBiasValue as String: -0.33,
+            kCGImagePropertyExifExposureMode as String: 0,
+            kCGImagePropertyExifExposureProgram as String: 2,
+            kCGImagePropertyExifExposureTime as String: 0.0125,
+            kCGImagePropertyExifFNumber as String: 2.8,
+            kCGImagePropertyExifFlash as String: 0,
+            kCGImagePropertyExifFocalLength as String: 50.0,
+            kCGImagePropertyExifFocalLenIn35mmFilm as String: 75,
+            kCGImagePropertyExifISOSpeedRatings as String: [800],
+            kCGImagePropertyExifLensMake as String: "Sony",
+            kCGImagePropertyExifLensModel as String: "FE 50mm F1.8",
+            kCGImagePropertyExifMeteringMode as String: 5,
+            kCGImagePropertyExifPixelXDimension as String: 6000,
+            kCGImagePropertyExifPixelYDimension as String: 4000,
+            kCGImagePropertyExifSceneCaptureType as String: 0,
+            kCGImagePropertyExifSensingMethod as String: 2,
+            kCGImagePropertyExifWhiteBalance as String: 0
+        ]
+        let exif = EXIF(rawValue: dict)
+        
+        #expect(exif.fNumber == 2.8)
+        #expect(exif.focalLength == 50.0)
+        #expect(exif.isoSpeedRatings == [800])
+        #expect(exif.lensModel == "FE 50mm F1.8")
+        #expect(exif.pixelXDimension == 6000)
+        #expect(exif.dateTimeOriginal != nil)
     }
 }
 


### PR DESCRIPTION
## Summary
Brings `develop` up to `main` with everything that's accumulated since the last merge:

- **AGENTS.md** — agent guidance for working in this repo.
- **Calendar extension tests** — coverage for `Calendar.date(bySettingTimeZone:of:)` and the underlying `TimeZone` helpers.
- **EXIF negative-offset fix** — corrects parsing of `OffsetTime*` strings with negative GMT offsets and expands EXIF test coverage.
- **DNG metadata support** (#4) — new `DNG` type covering every `kCGImagePropertyDNG*` key, wired through `MetadataOptions.dng`, `ImageMetadata.dng`, and the `imgmd` CLI (`--dng` / `--no-dng`, plus UTI-based auto-include for files conforming to `UTType.dng`). Bumps platforms to macOS 15 / iOS 18 / watchOS 11 / tvOS 18 to use `UTType.dng`.

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` passes (299 tests, including 56 new in `DNGTests` and 35 new in `CalendarTests`).
- [ ] Spot-check `imgmd` against a JPEG, DNG, and an EXIF image with a negative-offset `OffsetTime` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)