### PR TITLE
Add PNG metadata support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,19 +37,19 @@ The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCo
 
 1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
 2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
-3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG` structs only when the matching `MetadataOptions` flag is set.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG` structs only when the matching `MetadataOptions` flag is set.
 
-`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
 
 ### The `Metadata` protocol
 
-Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes.
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes.
 
 ### Sub-metadata structure
 
 Each metadata family lives in its own folder and follows the same pattern:
 
-- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
 - `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
 - `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ OPTIONS:
   -i, --iptc/--no-iptc    Include IPTC metadata. (default: --no-iptc)
   -t, --tiff/--no-tiff    Include TIFF metadata. (default: --no-tiff)
   --dng/--no-dng          Include DNG metadata. (default: --no-dng)
+  -p, --png/--no-png      Include PNG metadata. (default: --no-png)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
 

--- a/Sources/ImageMetadata/DNG/DNG.swift
+++ b/Sources/ImageMetadata/DNG/DNG.swift
@@ -430,23 +430,6 @@ public struct DNG: Metadata {
 
     // MARK: - Helpers
 
-    private static func intArray(_ value: Any?) -> [Int]? {
-        if let arr = value as? [Int] { return arr }
-        if let arr = value as? [NSNumber] { return arr.map(\.intValue) }
-        return nil
-    }
-
-    private static func doubleArray(_ value: Any?) -> [Double]? {
-        if let arr = value as? [Double] { return arr }
-        if let arr = value as? [NSNumber] { return arr.map(\.doubleValue) }
-        return nil
-    }
-
-    private static func describe(_ value: Any?) -> String? {
-        guard let value, !(value is NSNull) else { return nil }
-        return String(describing: value)
-    }
-
     private static func versionString(_ value: Any?) -> String? {
         guard let components = value as? [CustomStringConvertible] else { return nil }
         return components.map { String(describing: $0) }.joined(separator: ".")

--- a/Sources/ImageMetadata/ImageMetadata+Encodable.swift
+++ b/Sources/ImageMetadata/ImageMetadata+Encodable.swift
@@ -21,6 +21,7 @@ extension ImageMetadata: Encodable {
         case tiff
         case gps
         case dng
+        case png
         case imageFile = "file"
     }
     
@@ -60,6 +61,10 @@ extension ImageMetadata: Encodable {
 
         if options.contains(.dng) {
             try container.encodeIfPresent(dng, forKey: .dng)
+        }
+
+        if options.contains(.png) {
+            try container.encodeIfPresent(png, forKey: .png)
         }
 
         if let imageFile {

--- a/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
+++ b/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
@@ -26,6 +26,7 @@ See <doc:Usage>.
 - ``TIFF``
 - ``GPS``
 - ``DNG``
+- ``PNG``
 
 ### Creating an `ImageMetadata` type.
 

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -70,6 +70,9 @@ public struct ImageMetadata: Metadata {
     /// Metadata for an image that uses Adobe's Digital Negative (DNG) raw format.
     public let dng: DNG?
 
+    /// Metadata for an image that uses Portable Network Graphics (PNG) format.
+    public let png: PNG?
+
     public private(set) var imageFile: ImageFile?
     
 
@@ -136,13 +139,19 @@ public struct ImageMetadata: Metadata {
         } else {
             self.gps = nil
         }
-        
+
         if options.contains(.dng), let dngDictionary = rawValue[kCGImagePropertyDNGDictionary] as? NSDictionary {
             self.dng = DNG(rawValue: dngDictionary)
         } else {
             self.dng = nil
         }
-        
+
+        if options.contains(.png), let pngDictionary = rawValue[kCGImagePropertyPNGDictionary] as? NSDictionary {
+            self.png = PNG(rawValue: pngDictionary)
+        } else {
+            self.png = nil
+        }
+
         // Defaults that may be updated in other initializers
         self.contentType = nil
         self.imageFile = nil

--- a/Sources/ImageMetadata/Metadata+Helpers.swift
+++ b/Sources/ImageMetadata/Metadata+Helpers.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension Metadata {
+    /// Coerce a value from an `NSDictionary` into `[Int]?`, handling both the
+    /// already-bridged `[Int]` form and the underlying `[NSNumber]` form that
+    /// Core Foundation typically hands back.
+    static func intArray(_ value: Any?) -> [Int]? {
+        if let arr = value as? [Int] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.intValue) }
+        return nil
+    }
+
+    /// Coerce a value from an `NSDictionary` into `[Double]?`, handling both the
+    /// already-bridged `[Double]` form and the underlying `[NSNumber]` form.
+    static func doubleArray(_ value: Any?) -> [Double]? {
+        if let arr = value as? [Double] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.doubleValue) }
+        return nil
+    }
+
+    /// String description of an arbitrary value, returning `nil` for missing
+    /// or `NSNull` entries.
+    static func describe(_ value: Any?) -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        return String(describing: value)
+    }
+}

--- a/Sources/ImageMetadata/MetadataOptions.swift
+++ b/Sources/ImageMetadata/MetadataOptions.swift
@@ -16,8 +16,10 @@ public struct MetadataOptions: OptionSet, Sendable {
     public static let gps  = MetadataOptions(rawValue: 1 << 3)
     /// Include DNG Metadata.
     public static let dng  = MetadataOptions(rawValue: 1 << 4)
+    /// Include PNG Metadata.
+    public static let png  = MetadataOptions(rawValue: 1 << 5)
     /// Don't include any additional metadata types.
     public static let none: MetadataOptions = []
     /// Include all known metadata types.
-    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng]
+    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png]
 }

--- a/Sources/ImageMetadata/PNG/PNG+Encodable.swift
+++ b/Sources/ImageMetadata/PNG/PNG+Encodable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+extension PNG: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case author
+        case comment
+        case copyright
+        case imageDescription = "description"
+        case disclaimer
+        case software
+        case source
+        case title
+        case warning
+
+        case creationTime
+        case modificationTime
+
+        case chromaticities
+        case gamma
+        case sRGBIntent
+        case transparency
+
+        case compressionFilter
+        case interlaceType
+
+        case pixelsAspectRatio
+        case xPixelsPerMeter
+        case yPixelsPerMeter
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(author, forKey: .author)
+        try container.encodeIfPresent(comment, forKey: .comment)
+        try container.encodeIfPresent(copyright, forKey: .copyright)
+        try container.encodeIfPresent(imageDescription, forKey: .imageDescription)
+        try container.encodeIfPresent(disclaimer, forKey: .disclaimer)
+        try container.encodeIfPresent(software, forKey: .software)
+        try container.encodeIfPresent(source, forKey: .source)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(warning, forKey: .warning)
+
+        try container.encodeIfPresent(creationTime, forKey: .creationTime)
+        try container.encodeIfPresent(modificationTime, forKey: .modificationTime)
+
+        try container.encodeIfPresent(chromaticities, forKey: .chromaticities)
+        try container.encodeIfPresent(gamma, forKey: .gamma)
+        try container.encodeIfPresent(sRGBIntent, forKey: .sRGBIntent)
+        try container.encodeIfPresent(transparency, forKey: .transparency)
+
+        try container.encodeIfPresent(compressionFilter, forKey: .compressionFilter)
+        try container.encodeIfPresent(interlaceType, forKey: .interlaceType)
+
+        try container.encodeIfPresent(pixelsAspectRatio, forKey: .pixelsAspectRatio)
+        try container.encodeIfPresent(xPixelsPerMeter, forKey: .xPixelsPerMeter)
+        try container.encodeIfPresent(yPixelsPerMeter, forKey: .yPixelsPerMeter)
+    }
+}

--- a/Sources/ImageMetadata/PNG/PNG.swift
+++ b/Sources/ImageMetadata/PNG/PNG.swift
@@ -1,0 +1,143 @@
+public import Foundation
+import ImageIO
+
+/// Portable Network Graphics (PNG)
+///
+/// Keys mirror Apple's [PNG Image Properties](https://developer.apple.com/documentation/imageio/png-image-properties).
+public struct PNG: Metadata {
+
+    // MARK: - Text-chunk metadata
+
+    /// The image's author.
+    public let author: String?
+
+    /// A free-form comment.
+    public let comment: String?
+
+    /// Copyright information.
+    public let copyright: String?
+
+    /// A description of the image.
+    public let imageDescription: String?
+
+    /// A legal disclaimer.
+    public let disclaimer: String?
+
+    /// The name and version of the software used to create the image.
+    public let software: String?
+
+    /// The original source of the image (e.g. scanner, camera).
+    public let source: String?
+
+    /// The image title.
+    public let title: String?
+
+    /// A warning about the image's content.
+    public let warning: String?
+
+    // MARK: - Timestamps
+
+    /// The time the image was originally created.
+    public let creationTime: Date?
+
+    /// The time the image was last modified.
+    public let modificationTime: Date?
+
+    // MARK: - Color & display
+
+    /// CIE chromaticity coordinates of the white point and primaries:
+    /// `[whiteX, whiteY, redX, redY, greenX, greenY, blueX, blueY]`.
+    public let chromaticities: [Double]?
+
+    /// The image's gamma value.
+    public let gamma: Double?
+
+    /// The rendering intent for the embedded sRGB profile.
+    public let sRGBIntent: Int?
+
+    /// Per-channel transparency information from the `tRNS` chunk.
+    /// Interpretation depends on the PNG color type.
+    public let transparency: [Int]?
+
+    // MARK: - Encoding
+
+    /// The compression filter used.
+    public let compressionFilter: Int?
+
+    /// The interlace type. `0` = none, `1` = Adam7.
+    public let interlaceType: Int?
+
+    // MARK: - Physical size
+
+    /// Aspect ratio of pixels in the image.
+    public let pixelsAspectRatio: Double?
+
+    /// Number of pixels per meter along the x-axis.
+    public let xPixelsPerMeter: Int?
+
+    /// Number of pixels per meter along the y-axis.
+    public let yPixelsPerMeter: Int?
+
+    // MARK: - Initialization
+
+    public init(rawValue: NSDictionary) {
+        self.author = rawValue[kCGImagePropertyPNGAuthor] as? String
+        self.comment = rawValue[kCGImagePropertyPNGComment] as? String
+        self.copyright = rawValue[kCGImagePropertyPNGCopyright] as? String
+        self.imageDescription = rawValue[kCGImagePropertyPNGDescription] as? String
+        self.disclaimer = rawValue[kCGImagePropertyPNGDisclaimer] as? String
+        self.software = rawValue[kCGImagePropertyPNGSoftware] as? String
+        self.source = rawValue[kCGImagePropertyPNGSource] as? String
+        self.title = rawValue[kCGImagePropertyPNGTitle] as? String
+        self.warning = rawValue[kCGImagePropertyPNGWarning] as? String
+
+        self.creationTime = Self.parseDate(rawValue[kCGImagePropertyPNGCreationTime])
+        self.modificationTime = Self.parseDate(rawValue[kCGImagePropertyPNGModificationTime])
+
+        self.chromaticities = Self.doubleArray(rawValue[kCGImagePropertyPNGChromaticities])
+        self.gamma = rawValue[kCGImagePropertyPNGGamma] as? Double
+        self.sRGBIntent = rawValue[kCGImagePropertyPNGsRGBIntent] as? Int
+        self.transparency = Self.intArray(rawValue[kCGImagePropertyPNGTransparency])
+
+        self.compressionFilter = rawValue[kCGImagePropertyPNGCompressionFilter] as? Int
+        self.interlaceType = rawValue[kCGImagePropertyPNGInterlaceType] as? Int
+
+        self.pixelsAspectRatio = rawValue[kCGImagePropertyPNGPixelsAspectRatio] as? Double
+        self.xPixelsPerMeter = rawValue[kCGImagePropertyPNGXPixelsPerMeter] as? Int
+        self.yPixelsPerMeter = rawValue[kCGImagePropertyPNGYPixelsPerMeter] as? Int
+    }
+
+    // MARK: - Helpers
+
+    private static func intArray(_ value: Any?) -> [Int]? {
+        if let arr = value as? [Int] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.intValue) }
+        return nil
+    }
+
+    private static func doubleArray(_ value: Any?) -> [Double]? {
+        if let arr = value as? [Double] { return arr }
+        if let arr = value as? [NSNumber] { return arr.map(\.doubleValue) }
+        return nil
+    }
+
+    /// PNG date strings are inconsistent in the wild. The PNG spec recommends
+    /// RFC 1123 format (e.g. "Mon, 17 Jan 2000 07:34:51 GMT"); ISO 8601 is also
+    /// common. Try both before giving up.
+    private static func parseDate(_ value: Any?) -> Date? {
+        guard let string = value as? String else { return nil }
+
+        if let iso = try? Date.ISO8601FormatStyle().parse(string) {
+            return iso
+        }
+
+        let rfc1123 = DateFormatter()
+        rfc1123.locale = Locale(identifier: "en_US_POSIX")
+        rfc1123.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        if let date = rfc1123.date(from: string) {
+            return date
+        }
+
+        return nil
+    }
+}

--- a/Sources/ImageMetadata/PNG/PNG.swift
+++ b/Sources/ImageMetadata/PNG/PNG.swift
@@ -109,18 +109,6 @@ public struct PNG: Metadata {
 
     // MARK: - Helpers
 
-    private static func intArray(_ value: Any?) -> [Int]? {
-        if let arr = value as? [Int] { return arr }
-        if let arr = value as? [NSNumber] { return arr.map(\.intValue) }
-        return nil
-    }
-
-    private static func doubleArray(_ value: Any?) -> [Double]? {
-        if let arr = value as? [Double] { return arr }
-        if let arr = value as? [NSNumber] { return arr.map(\.doubleValue) }
-        return nil
-    }
-
     /// PNG date strings are inconsistent in the wild. The PNG spec recommends
     /// RFC 1123 format (e.g. "Mon, 17 Jan 2000 07:34:51 GMT"); ISO 8601 is also
     /// common. Try both before giving up.

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -63,6 +63,16 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-dng:**
 
 *Include DNG metadata.*
+
+
+**--png:**
+
+*Include PNG metadata.*
+
+
+**--no-png:**
+
+*Include PNG metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -101,8 +101,13 @@ struct imgmd: ParsableCommand {
 
         let imagesMetadata = try files.map { url -> ImageMetadata in
             var options = metadataOptions
-            if !basic, Self.isDNG(url: url) {
-                options.insert(.dng)
+            if !basic {
+                if Self.conforms(url: url, to: .dng) {
+                    options.insert(.dng)
+                }
+                if Self.conforms(url: url, to: .png) {
+                    options.insert(.png)
+                }
             }
             return try ImageMetadata(url: url, options: options)
         }
@@ -124,11 +129,11 @@ struct imgmd: ParsableCommand {
         print(String(decoding: json, as: UTF8.self))
     }
 
-    private static func isDNG(url: URL) -> Bool {
+    private static func conforms(url: URL, to target: UTType) -> Bool {
         guard let values = try? url.resourceValues(forKeys: [.contentTypeKey]),
               let type = values.contentType else {
             return false
         }
-        return type.conforms(to: .dng)
+        return type.conforms(to: target)
     }
 }

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -4,7 +4,7 @@ import ImageMetadata
 import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps, dng
+    case exif, iptc, tiff, gps, dng, png
 }
 
 fileprivate extension MetadataType {
@@ -20,6 +20,8 @@ fileprivate extension MetadataType {
             return .gps
         case .dng:
             return .dng
+        case .png:
+            return .png
         }
     }
 }
@@ -52,6 +54,9 @@ struct imgmd: ParsableCommand {
 
     @Flag(name: .long, inversion: .prefixedNo, help: "Include DNG metadata.")
     var dng: Bool = false
+
+    @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include PNG metadata.")
+    var png: Bool = false
 
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
@@ -86,6 +91,7 @@ struct imgmd: ParsableCommand {
         if tiff { metadataOptions.insert(.tiff) }
         if gps { metadataOptions.insert(.gps) }
         if dng { metadataOptions.insert(.dng) }
+        if png { metadataOptions.insert(.png) }
 
         if basic {
             metadataOptions = MetadataOptions.none

--- a/Tests/ImageMetadataTests/MetadataHelpersTests.swift
+++ b/Tests/ImageMetadataTests/MetadataHelpersTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import ImageMetadata
+
+
+/// Minimal `Metadata` conformer used to invoke the static helpers under test.
+private struct TestMetadata: Metadata {}
+
+
+struct MetadataHelpersTests {
+
+    // MARK: - intArray
+
+    @Test("intArray returns nil for nil input")
+    func intArrayNil() {
+        #expect(TestMetadata.intArray(nil) == nil)
+    }
+
+    @Test("intArray returns nil for NSNull")
+    func intArrayNSNull() {
+        #expect(TestMetadata.intArray(NSNull()) == nil)
+    }
+
+    @Test("intArray passes through a native [Int]")
+    func intArrayNativeInt() {
+        #expect(TestMetadata.intArray([1, 2, 3]) == [1, 2, 3])
+    }
+
+    @Test("intArray bridges [NSNumber]")
+    func intArrayNSNumberBridge() {
+        let nsNumbers: [NSNumber] = [NSNumber(value: 7), NSNumber(value: 11), NSNumber(value: 13)]
+        #expect(TestMetadata.intArray(nsNumbers) == [7, 11, 13])
+    }
+
+    @Test("intArray truncates [NSNumber] containing doubles")
+    func intArrayNSNumberDoubleTruncates() {
+        let nsNumbers: [NSNumber] = [NSNumber(value: 1.7), NSNumber(value: 2.9)]
+        #expect(TestMetadata.intArray(nsNumbers) == [1, 2])
+    }
+
+    @Test("intArray returns empty for empty array")
+    func intArrayEmpty() {
+        #expect(TestMetadata.intArray([] as [Int]) == [])
+        #expect(TestMetadata.intArray([] as [NSNumber]) == [])
+    }
+
+    @Test("intArray returns nil for non-array input")
+    func intArrayWrongType() {
+        #expect(TestMetadata.intArray("not an array") == nil)
+        #expect(TestMetadata.intArray(42) == nil)
+    }
+
+    @Test("intArray returns nil for [String]")
+    func intArrayWrongElementType() {
+        #expect(TestMetadata.intArray(["1", "2"]) == nil)
+    }
+
+    // MARK: - doubleArray
+
+    @Test("doubleArray returns nil for nil input")
+    func doubleArrayNil() {
+        #expect(TestMetadata.doubleArray(nil) == nil)
+    }
+
+    @Test("doubleArray returns nil for NSNull")
+    func doubleArrayNSNull() {
+        #expect(TestMetadata.doubleArray(NSNull()) == nil)
+    }
+
+    @Test("doubleArray passes through a native [Double]")
+    func doubleArrayNativeDouble() {
+        #expect(TestMetadata.doubleArray([1.5, 2.5, 3.5]) == [1.5, 2.5, 3.5])
+    }
+
+    @Test("doubleArray bridges [NSNumber] with double values")
+    func doubleArrayNSNumberDoubleBridge() {
+        let nsNumbers: [NSNumber] = [NSNumber(value: 0.5), NSNumber(value: 1.25)]
+        #expect(TestMetadata.doubleArray(nsNumbers) == [0.5, 1.25])
+    }
+
+    @Test("doubleArray bridges [NSNumber] with integer values")
+    func doubleArrayNSNumberIntBridge() {
+        let nsNumbers: [NSNumber] = [NSNumber(value: 1), NSNumber(value: 2)]
+        #expect(TestMetadata.doubleArray(nsNumbers) == [1.0, 2.0])
+    }
+
+    @Test("doubleArray returns empty for empty array")
+    func doubleArrayEmpty() {
+        #expect(TestMetadata.doubleArray([] as [Double]) == [])
+        #expect(TestMetadata.doubleArray([] as [NSNumber]) == [])
+    }
+
+    @Test("doubleArray returns nil for non-array input")
+    func doubleArrayWrongType() {
+        #expect(TestMetadata.doubleArray("not an array") == nil)
+        #expect(TestMetadata.doubleArray(3.14) == nil)
+    }
+
+    // MARK: - describe
+
+    @Test("describe returns nil for nil input")
+    func describeNil() {
+        #expect(TestMetadata.describe(nil) == nil)
+    }
+
+    @Test("describe returns nil for NSNull")
+    func describeNSNull() {
+        #expect(TestMetadata.describe(NSNull()) == nil)
+    }
+
+    @Test("describe stringifies common scalar values")
+    func describeScalars() {
+        #expect(TestMetadata.describe("hello") == "hello")
+        #expect(TestMetadata.describe(42) == "42")
+        #expect(TestMetadata.describe(3.5) == "3.5")
+        #expect(TestMetadata.describe(true) == "true")
+    }
+
+    @Test("describe stringifies a dictionary")
+    func describeDictionary() throws {
+        let value: [String: Double] = ["k0": 1.0, "k1": 2.0]
+        let result = try #require(TestMetadata.describe(value))
+        // Dictionary order isn't guaranteed; just verify the keys are present.
+        #expect(result.contains("k0"))
+        #expect(result.contains("k1"))
+    }
+}

--- a/Tests/ImageMetadataTests/PNGTests.swift
+++ b/Tests/ImageMetadataTests/PNGTests.swift
@@ -1,0 +1,204 @@
+import Testing
+import Foundation
+import ImageIO
+@testable import ImageMetadata
+
+
+struct PNGTests {
+    static func sampleRawPNG() -> NSDictionary {
+        return [
+            kCGImagePropertyPNGAuthor: "Joseph Nicéphore Niépce",
+            kCGImagePropertyPNGComment: "Test image",
+            kCGImagePropertyPNGCopyright: "Public Domain",
+            kCGImagePropertyPNGDescription: "An example PNG",
+            kCGImagePropertyPNGDisclaimer: "Use at your own risk.",
+            kCGImagePropertyPNGSoftware: "Adobe Photoshop",
+            kCGImagePropertyPNGSource: "Camera Obscura",
+            kCGImagePropertyPNGTitle: "View from the Window at Le Gras",
+            kCGImagePropertyPNGWarning: "Contains sample bits.",
+
+            kCGImagePropertyPNGCreationTime: "2025-02-13T15:34:57Z",
+            kCGImagePropertyPNGModificationTime: "Sun, 13 Feb 2025 15:34:57 GMT",
+
+            kCGImagePropertyPNGChromaticities: [0.3127, 0.3290, 0.64, 0.33, 0.30, 0.60, 0.15, 0.06],
+            kCGImagePropertyPNGGamma: 2.2,
+            kCGImagePropertyPNGsRGBIntent: 0,
+            kCGImagePropertyPNGTransparency: [0, 255, 0],
+
+            kCGImagePropertyPNGCompressionFilter: 5,
+            kCGImagePropertyPNGInterlaceType: 1,
+
+            kCGImagePropertyPNGPixelsAspectRatio: 1.0,
+            kCGImagePropertyPNGXPixelsPerMeter: 2835,
+            kCGImagePropertyPNGYPixelsPerMeter: 2835,
+        ]
+    }
+
+    let png: PNG
+
+    init() {
+        self.png = PNG(rawValue: Self.sampleRawPNG())
+    }
+
+    // MARK: - Text fields
+
+    @Test func author() {
+        #expect(png.author == "Joseph Nicéphore Niépce")
+    }
+
+    @Test func comment() {
+        #expect(png.comment == "Test image")
+    }
+
+    @Test func copyright() {
+        #expect(png.copyright == "Public Domain")
+    }
+
+    @Test func imageDescription() {
+        #expect(png.imageDescription == "An example PNG")
+    }
+
+    @Test func disclaimer() {
+        #expect(png.disclaimer == "Use at your own risk.")
+    }
+
+    @Test func software() {
+        #expect(png.software == "Adobe Photoshop")
+    }
+
+    @Test func source() {
+        #expect(png.source == "Camera Obscura")
+    }
+
+    @Test func title() {
+        #expect(png.title == "View from the Window at Le Gras")
+    }
+
+    @Test func warning() {
+        #expect(png.warning == "Contains sample bits.")
+    }
+
+    // MARK: - Timestamps
+
+    @Test("creationTime parses ISO 8601")
+    func creationTimeISO8601() throws {
+        let date = try #require(png.creationTime)
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: TimeZone(identifier: "UTC")!,
+            from: date
+        )
+        #expect(components.year == 2025)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 15)
+        #expect(components.minute == 34)
+        #expect(components.second == 57)
+    }
+
+    @Test("modificationTime falls back to RFC 1123")
+    func modificationTimeRFC1123() throws {
+        let date = try #require(png.modificationTime)
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: TimeZone(identifier: "UTC")!,
+            from: date
+        )
+        #expect(components.year == 2025)
+        #expect(components.month == 2)
+        #expect(components.day == 13)
+        #expect(components.hour == 15)
+        #expect(components.minute == 34)
+        #expect(components.second == 57)
+    }
+
+    // MARK: - Color
+
+    @Test func chromaticities() {
+        #expect(png.chromaticities == [0.3127, 0.3290, 0.64, 0.33, 0.30, 0.60, 0.15, 0.06])
+    }
+
+    @Test func gamma() {
+        #expect(png.gamma == 2.2)
+    }
+
+    @Test func sRGBIntent() {
+        #expect(png.sRGBIntent == 0)
+    }
+
+    @Test func transparency() {
+        #expect(png.transparency == [0, 255, 0])
+    }
+
+    // MARK: - Encoding
+
+    @Test func compressionFilter() {
+        #expect(png.compressionFilter == 5)
+    }
+
+    @Test func interlaceType() {
+        #expect(png.interlaceType == 1)
+    }
+
+    // MARK: - Physical size
+
+    @Test func pixelsAspectRatio() {
+        #expect(png.pixelsAspectRatio == 1.0)
+    }
+
+    @Test func pixelsPerMeter() {
+        #expect(png.xPixelsPerMeter == 2835)
+        #expect(png.yPixelsPerMeter == 2835)
+    }
+
+    // MARK: - Encoding behavior
+
+    @Test("Encoding emits present fields and omits nils")
+    func encoding() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let data = try encoder.encode(png)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["author"] as? String == "Joseph Nicéphore Niépce")
+        #expect(json["title"] as? String == "View from the Window at Le Gras")
+        #expect(json["description"] as? String == "An example PNG")
+        #expect(json["gamma"] as? Double == 2.2)
+        #expect(json["sRGBIntent"] as? Int == 0)
+        #expect(json["chromaticities"] as? [Double] == [0.3127, 0.3290, 0.64, 0.33, 0.30, 0.60, 0.15, 0.06])
+        #expect(json["transparency"] as? [Int] == [0, 255, 0])
+        #expect(json["xPixelsPerMeter"] as? Int == 2835)
+
+        let creation = try #require(json["creationTime"] as? String)
+        #expect(creation.hasPrefix("2025-02-13T15:34:57"))
+    }
+
+    @Test("Missing or malformed values produce nils")
+    func missingOrMalformedValues() {
+        let raw = Self.sampleRawPNG().mutableCopy() as! NSMutableDictionary
+        raw[kCGImagePropertyPNGGamma] = "not-a-double"
+        raw[kCGImagePropertyPNGCreationTime] = "garbage"
+        raw[kCGImagePropertyPNGsRGBIntent] = NSNull()
+        raw.removeObject(forKey: kCGImagePropertyPNGAuthor)
+
+        let png = PNG(rawValue: raw)
+
+        #expect(png.gamma == nil)
+        #expect(png.creationTime == nil)
+        #expect(png.sRGBIntent == nil)
+        #expect(png.author == nil)
+    }
+
+    @Test("Empty dictionary produces an all-nil PNG that encodes to {}")
+    func emptyDictionary() throws {
+        let png = PNG(rawValue: [:])
+
+        #expect(png.author == nil)
+        #expect(png.gamma == nil)
+        #expect(png.creationTime == nil)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(png)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New `PNG` metadata type covering every key in [PNG Image Properties](https://developer.apple.com/documentation/imageio/png-image-properties), conforming to `Metadata`.
- Wires PNG into `MetadataOptions.png` (bit 5) / `ImageMetadata.png` and the `imgmd` CLI (`-p` / `--png` / `--no-png`, plus UTI-based auto-include for files conforming to `UTType.png` — same pattern as DNG).
- Extracts the duplicated `intArray` / `doubleArray` / `describe` helpers from `DNG.swift` and `PNG.swift` into a shared extension on `Metadata` so future conformers get them for free.
- Adds 22 PNG tests and 19 helper-coverage tests (`[NSNumber]` bridging, `NSNull`, `nil`, wrong-type inputs — paths the integration tests don't exercise).

## Notes
- `PNG.creationTime` / `modificationTime` parse ISO 8601 first and fall back to RFC 1123. The PNG spec doesn't strictly enforce a single format, so silent `nil` is the failure mode for unrecognized strings.
- `imageDescription` Swift property maps to the `description` JSON key (avoids clashing with `CustomStringConvertible.description`, mirroring how TIFF handles the same field).
- The CLI helper that was `isDNG(url:)` is now a generic `conforms(url:to:)` so it serves both auto-include checks.

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` — 340 tests pass (22 new in `PNGTests`, 19 new in `MetadataHelpersTests`).
- [ ] Spot-check `imgmd <some.png>` and confirm the `png` block appears in JSON output.
- [ ] Spot-check `imgmd --exif <some.png>` to confirm PNG is auto-added by the UTI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)