### PR TITLE
Add GIF metadata support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,19 +37,19 @@ The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCo
 
 1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
 2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
-3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG` structs only when the matching `MetadataOptions` flag is set.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`, `GIFDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF` structs only when the matching `MetadataOptions` flag is set.
 
-`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.gif`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
 
 ### The `Metadata` protocol
 
-Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes.
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes; `GIF` does the same with `imageColorMap`.
 
 ### Sub-metadata structure
 
 Each metadata family lives in its own folder and follows the same pattern:
 
-- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/`, `GIF/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
 - `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
 - `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ OPTIONS:
   -t, --tiff/--no-tiff    Include TIFF metadata. (default: --no-tiff)
   --dng/--no-dng          Include DNG metadata. (default: --no-dng)
   -p, --png/--no-png      Include PNG metadata. (default: --no-png)
+  --gif/--no-gif          Include GIF metadata. (default: --no-gif)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
 

--- a/Sources/ImageMetadata/GIF/GIF+Encodable.swift
+++ b/Sources/ImageMetadata/GIF/GIF+Encodable.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension GIF: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case canvasPixelWidth
+        case canvasPixelHeight
+
+        case delayTime
+        case unclampedDelayTime
+        case loopCount
+        case frameInfoArray
+
+        case hasGlobalColorMap
+        case imageColorMap
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(canvasPixelWidth, forKey: .canvasPixelWidth)
+        try container.encodeIfPresent(canvasPixelHeight, forKey: .canvasPixelHeight)
+
+        try container.encodeIfPresent(delayTime, forKey: .delayTime)
+        try container.encodeIfPresent(unclampedDelayTime, forKey: .unclampedDelayTime)
+        try container.encodeIfPresent(loopCount, forKey: .loopCount)
+        try container.encodeIfPresent(frameInfoArray, forKey: .frameInfoArray)
+
+        try container.encodeIfPresent(hasGlobalColorMap, forKey: .hasGlobalColorMap)
+        try container.encodeIfPresent(imageColorMap?.count, forKey: .imageColorMap)
+    }
+}

--- a/Sources/ImageMetadata/GIF/GIF.swift
+++ b/Sources/ImageMetadata/GIF/GIF.swift
@@ -1,0 +1,60 @@
+public import Foundation
+import ImageIO
+
+/// Graphics Interchange Format (GIF)
+///
+/// Keys mirror Apple's [GIF Image Properties](https://developer.apple.com/documentation/imageio/gif-image-properties).
+public struct GIF: Metadata {
+
+    // MARK: - Canvas
+
+    /// Width of the logical screen the frames composite onto.
+    public let canvasPixelWidth: Int?
+
+    /// Height of the logical screen the frames composite onto.
+    public let canvasPixelHeight: Int?
+
+    // MARK: - Animation
+
+    /// The clamped frame delay in seconds. Browsers typically enforce a minimum
+    /// (around 0.1s) — see ``unclampedDelayTime`` for the original value.
+    public let delayTime: Double?
+
+    /// The original frame delay in seconds, before any browser-side clamping.
+    public let unclampedDelayTime: Double?
+
+    /// The number of times the animation should loop. `0` means infinite.
+    public let loopCount: Int?
+
+    /// Stringified per-frame metadata dictionaries. The exact keys aren't
+    /// publicly documented, so each frame is represented as a single string.
+    public let frameInfoArray: [String]?
+
+    // MARK: - Color
+
+    /// Whether the GIF has a global color map (palette).
+    public let hasGlobalColorMap: Bool?
+
+    /// The GIF's color map as raw palette bytes.
+    public let imageColorMap: Data?
+
+    // MARK: - Initialization
+
+    public init(rawValue: NSDictionary) {
+        self.canvasPixelWidth = rawValue[kCGImagePropertyGIFCanvasPixelWidth] as? Int
+        self.canvasPixelHeight = rawValue[kCGImagePropertyGIFCanvasPixelHeight] as? Int
+
+        self.delayTime = rawValue[kCGImagePropertyGIFDelayTime] as? Double
+        self.unclampedDelayTime = rawValue[kCGImagePropertyGIFUnclampedDelayTime] as? Double
+        self.loopCount = rawValue[kCGImagePropertyGIFLoopCount] as? Int
+
+        if let frames = rawValue[kCGImagePropertyGIFFrameInfoArray] as? [Any] {
+            self.frameInfoArray = frames.compactMap(Self.describe)
+        } else {
+            self.frameInfoArray = nil
+        }
+
+        self.hasGlobalColorMap = rawValue[kCGImagePropertyGIFHasGlobalColorMap] as? Bool
+        self.imageColorMap = rawValue[kCGImagePropertyGIFImageColorMap] as? Data
+    }
+}

--- a/Sources/ImageMetadata/ImageMetadata+Encodable.swift
+++ b/Sources/ImageMetadata/ImageMetadata+Encodable.swift
@@ -22,6 +22,7 @@ extension ImageMetadata: Encodable {
         case gps
         case dng
         case png
+        case gif
         case imageFile = "file"
     }
     
@@ -65,6 +66,10 @@ extension ImageMetadata: Encodable {
 
         if options.contains(.png) {
             try container.encodeIfPresent(png, forKey: .png)
+        }
+
+        if options.contains(.gif) {
+            try container.encodeIfPresent(gif, forKey: .gif)
         }
 
         if let imageFile {

--- a/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
+++ b/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
@@ -27,6 +27,7 @@ See <doc:Usage>.
 - ``GPS``
 - ``DNG``
 - ``PNG``
+- ``GIF``
 
 ### Creating an `ImageMetadata` type.
 

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -73,6 +73,9 @@ public struct ImageMetadata: Metadata {
     /// Metadata for an image that uses Portable Network Graphics (PNG) format.
     public let png: PNG?
 
+    /// Metadata for an image that uses Graphics Interchange Format (GIF).
+    public let gif: GIF?
+
     public private(set) var imageFile: ImageFile?
     
 
@@ -150,6 +153,12 @@ public struct ImageMetadata: Metadata {
             self.png = PNG(rawValue: pngDictionary)
         } else {
             self.png = nil
+        }
+
+        if options.contains(.gif), let gifDictionary = rawValue[kCGImagePropertyGIFDictionary] as? NSDictionary {
+            self.gif = GIF(rawValue: gifDictionary)
+        } else {
+            self.gif = nil
         }
 
         // Defaults that may be updated in other initializers

--- a/Sources/ImageMetadata/MetadataOptions.swift
+++ b/Sources/ImageMetadata/MetadataOptions.swift
@@ -18,8 +18,10 @@ public struct MetadataOptions: OptionSet, Sendable {
     public static let dng  = MetadataOptions(rawValue: 1 << 4)
     /// Include PNG Metadata.
     public static let png  = MetadataOptions(rawValue: 1 << 5)
+    /// Include GIF Metadata.
+    public static let gif  = MetadataOptions(rawValue: 1 << 6)
     /// Don't include any additional metadata types.
     public static let none: MetadataOptions = []
     /// Include all known metadata types.
-    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png]
+    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png, .gif]
 }

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -73,6 +73,16 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-png:**
 
 *Include PNG metadata.*
+
+
+**--gif:**
+
+*Include GIF metadata.*
+
+
+**--no-gif:**
+
+*Include GIF metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -4,7 +4,7 @@ import ImageMetadata
 import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps, dng, png
+    case exif, iptc, tiff, gps, dng, png, gif
 }
 
 fileprivate extension MetadataType {
@@ -22,6 +22,8 @@ fileprivate extension MetadataType {
             return .dng
         case .png:
             return .png
+        case .gif:
+            return .gif
         }
     }
 }
@@ -58,6 +60,9 @@ struct imgmd: ParsableCommand {
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include PNG metadata.")
     var png: Bool = false
 
+    @Flag(name: .long, inversion: .prefixedNo, help: "Include GIF metadata.")
+    var gif: Bool = false
+
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
     
@@ -92,6 +97,7 @@ struct imgmd: ParsableCommand {
         if gps { metadataOptions.insert(.gps) }
         if dng { metadataOptions.insert(.dng) }
         if png { metadataOptions.insert(.png) }
+        if gif { metadataOptions.insert(.gif) }
 
         if basic {
             metadataOptions = MetadataOptions.none
@@ -107,6 +113,9 @@ struct imgmd: ParsableCommand {
                 }
                 if Self.conforms(url: url, to: .png) {
                     options.insert(.png)
+                }
+                if Self.conforms(url: url, to: .gif) {
+                    options.insert(.gif)
                 }
             }
             return try ImageMetadata(url: url, options: options)

--- a/Tests/ImageMetadataTests/GIFTests.swift
+++ b/Tests/ImageMetadataTests/GIFTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+import ImageIO
+@testable import ImageMetadata
+
+
+struct GIFTests {
+    static func sampleRawGIF() -> NSDictionary {
+        return [
+            kCGImagePropertyGIFCanvasPixelWidth: 480,
+            kCGImagePropertyGIFCanvasPixelHeight: 320,
+            kCGImagePropertyGIFDelayTime: 0.1,
+            kCGImagePropertyGIFUnclampedDelayTime: 0.04,
+            kCGImagePropertyGIFLoopCount: 0,
+            kCGImagePropertyGIFFrameInfoArray: [
+                ["delay": 0.1] as NSDictionary,
+                ["delay": 0.1] as NSDictionary,
+                ["delay": 0.2] as NSDictionary,
+            ],
+            kCGImagePropertyGIFHasGlobalColorMap: true,
+            kCGImagePropertyGIFImageColorMap: Data(repeating: 0xAA, count: 768),
+        ]
+    }
+
+    let gif: GIF
+
+    init() {
+        self.gif = GIF(rawValue: Self.sampleRawGIF())
+    }
+
+    // MARK: - Canvas
+
+    @Test func canvasPixelWidth() {
+        #expect(gif.canvasPixelWidth == 480)
+    }
+
+    @Test func canvasPixelHeight() {
+        #expect(gif.canvasPixelHeight == 320)
+    }
+
+    // MARK: - Animation
+
+    @Test func delayTime() {
+        #expect(gif.delayTime == 0.1)
+    }
+
+    @Test func unclampedDelayTime() {
+        #expect(gif.unclampedDelayTime == 0.04)
+    }
+
+    @Test func loopCount() {
+        #expect(gif.loopCount == 0)
+    }
+
+    @Test func frameInfoArray() {
+        #expect(gif.frameInfoArray?.count == 3)
+    }
+
+    // MARK: - Color
+
+    @Test func hasGlobalColorMap() {
+        #expect(gif.hasGlobalColorMap == true)
+    }
+
+    @Test func imageColorMap() {
+        #expect(gif.imageColorMap?.count == 768)
+    }
+
+    // MARK: - Encoding
+
+    @Test("Encoding emits present fields and uses byte count for color map")
+    func encoding() throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(gif)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["canvasPixelWidth"] as? Int == 480)
+        #expect(json["canvasPixelHeight"] as? Int == 320)
+        #expect(json["delayTime"] as? Double == 0.1)
+        #expect(json["unclampedDelayTime"] as? Double == 0.04)
+        #expect(json["loopCount"] as? Int == 0)
+        #expect(json["hasGlobalColorMap"] as? Bool == true)
+        // Replaced with byte count.
+        #expect(json["imageColorMap"] as? Int == 768)
+        // Stringified frame entries.
+        #expect((json["frameInfoArray"] as? [String])?.count == 3)
+    }
+
+    @Test("Missing or malformed values produce nils")
+    func missingOrMalformedValues() {
+        let raw = Self.sampleRawGIF().mutableCopy() as! NSMutableDictionary
+        raw[kCGImagePropertyGIFDelayTime] = "not-a-double"
+        raw[kCGImagePropertyGIFLoopCount] = NSNull()
+        raw.removeObject(forKey: kCGImagePropertyGIFCanvasPixelWidth)
+        raw.removeObject(forKey: kCGImagePropertyGIFFrameInfoArray)
+
+        let gif = GIF(rawValue: raw)
+
+        #expect(gif.delayTime == nil)
+        #expect(gif.loopCount == nil)
+        #expect(gif.canvasPixelWidth == nil)
+        #expect(gif.frameInfoArray == nil)
+    }
+
+    @Test("Empty dictionary produces an all-nil GIF that encodes to {}")
+    func emptyDictionary() throws {
+        let gif = GIF(rawValue: [:])
+
+        #expect(gif.canvasPixelWidth == nil)
+        #expect(gif.delayTime == nil)
+        #expect(gif.frameInfoArray == nil)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(gif)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New `GIF` metadata type covering every key in [GIF Image Properties](https://developer.apple.com/documentation/imageio/gif-image-properties), conforming to `Metadata`.
- Canvas (`canvasPixelWidth` / `canvasPixelHeight`), animation (`delayTime`, `unclampedDelayTime`, `loopCount`, `frameInfoArray`), and color (`hasGlobalColorMap`, `imageColorMap`).
- Wires into `MetadataOptions.gif` (bit 6) / `ImageMetadata.gif` and the `imgmd` CLI (`--gif` / `--no-gif`, plus UTI-based auto-include for files conforming to `UTType.gif`).
- Adds 11 GIF tests covering each field, encoding behavior, malformed inputs, and an empty-dictionary case.

## Notes
- `imageColorMap` is `Data?` in memory but encoded as an `Int` byte count, mirroring DNG's heavy-blob handling.
- `frameInfoArray` is typed as `[String]?` — each frame's dict gets stringified via the shared `describe` helper. The per-frame dict shape isn't publicly documented, so opaque-string is the safest representation. We can revisit with a structured `GIF.FrameInfo` once we have sample GIFs to validate against.
- `--gif` is long-only (the short `-g` is already taken by `--gps`), same compromise as `--dng`.

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` — 351 tests pass (11 new in `GIFTests`).
- [ ] Spot-check `imgmd <some.gif>` and confirm the `gif` block appears in JSON output.
- [ ] Spot-check `imgmd --exif <some.gif>` to confirm GIF is auto-added by the UTI check.
- [ ] Spot-check an animated GIF to see what `frameInfoArray` actually contains in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)