### PR TITLE
Add 8BIM (Photoshop) metadata support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,19 +37,19 @@ The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCo
 
 1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
 2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
-3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`, `GIFDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF` structs only when the matching `MetadataOptions` flag is set.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`, `GIFDictionary`, `8BIMDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM` structs only when the matching `MetadataOptions` flag is set.
 
-`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.gif`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.gif`, `.eightBIM`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
 
 ### The `Metadata` protocol
 
-Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes; `GIF` does the same with `imageColorMap`.
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes; `GIF` does the same with `imageColorMap`.
 
 ### Sub-metadata structure
 
 Each metadata family lives in its own folder and follows the same pattern:
 
-- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/`, `GIF/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/`, `GIF/`, `EightBIM/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
 - `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
 - `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ OPTIONS:
   --dng/--no-dng          Include DNG metadata. (default: --no-dng)
   -p, --png/--no-png      Include PNG metadata. (default: --no-png)
   --gif/--no-gif          Include GIF metadata. (default: --no-gif)
+  --8bim, --eight-bim/--no-8bim, --no-eight-bim
+                          Include 8BIM (Photoshop) metadata. (default: --no-8bim)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
 

--- a/Sources/ImageMetadata/EightBIM/EightBIM+Encodable.swift
+++ b/Sources/ImageMetadata/EightBIM/EightBIM+Encodable.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension EightBIM: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case layerNames
+        case version
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(layerNames, forKey: .layerNames)
+        try container.encodeIfPresent(version, forKey: .version)
+    }
+}

--- a/Sources/ImageMetadata/EightBIM/EightBIM.swift
+++ b/Sources/ImageMetadata/EightBIM/EightBIM.swift
@@ -1,0 +1,23 @@
+public import Foundation
+import ImageIO
+
+/// 8BIM (a.k.a. Photoshop image resource block) metadata.
+///
+/// Keys mirror Apple's [8BIM Image Properties](https://developer.apple.com/documentation/imageio/8bim-image-properties).
+/// 8BIM blocks aren't unique to PSD files — they're frequently embedded in
+/// JPEGs and TIFFs that Photoshop has touched.
+public struct EightBIM: Metadata {
+
+    /// Names of the layers in the image.
+    public let layerNames: [String]?
+
+    /// The 8BIM resource format version.
+    public let version: Int?
+
+    // MARK: - Initialization
+
+    public init(rawValue: NSDictionary) {
+        self.layerNames = rawValue[kCGImageProperty8BIMLayerNames] as? [String]
+        self.version = rawValue[kCGImageProperty8BIMVersion] as? Int
+    }
+}

--- a/Sources/ImageMetadata/ImageMetadata+Encodable.swift
+++ b/Sources/ImageMetadata/ImageMetadata+Encodable.swift
@@ -23,6 +23,7 @@ extension ImageMetadata: Encodable {
         case dng
         case png
         case gif
+        case eightBIM
         case imageFile = "file"
     }
     
@@ -70,6 +71,10 @@ extension ImageMetadata: Encodable {
 
         if options.contains(.gif) {
             try container.encodeIfPresent(gif, forKey: .gif)
+        }
+
+        if options.contains(.eightBIM) {
+            try container.encodeIfPresent(eightBIM, forKey: .eightBIM)
         }
 
         if let imageFile {

--- a/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
+++ b/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
@@ -28,6 +28,7 @@ See <doc:Usage>.
 - ``DNG``
 - ``PNG``
 - ``GIF``
+- ``EightBIM``
 
 ### Creating an `ImageMetadata` type.
 

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -76,6 +76,10 @@ public struct ImageMetadata: Metadata {
     /// Metadata for an image that uses Graphics Interchange Format (GIF).
     public let gif: GIF?
 
+    /// 8BIM (Photoshop image resource block) metadata. Often present in
+    /// PSD files but also embedded in JPEGs and TIFFs touched by Photoshop.
+    public let eightBIM: EightBIM?
+
     public private(set) var imageFile: ImageFile?
     
 
@@ -159,6 +163,12 @@ public struct ImageMetadata: Metadata {
             self.gif = GIF(rawValue: gifDictionary)
         } else {
             self.gif = nil
+        }
+
+        if options.contains(.eightBIM), let eightBIMDictionary = rawValue[kCGImageProperty8BIMDictionary] as? NSDictionary {
+            self.eightBIM = EightBIM(rawValue: eightBIMDictionary)
+        } else {
+            self.eightBIM = nil
         }
 
         // Defaults that may be updated in other initializers

--- a/Sources/ImageMetadata/MetadataOptions.swift
+++ b/Sources/ImageMetadata/MetadataOptions.swift
@@ -20,8 +20,10 @@ public struct MetadataOptions: OptionSet, Sendable {
     public static let png  = MetadataOptions(rawValue: 1 << 5)
     /// Include GIF Metadata.
     public static let gif  = MetadataOptions(rawValue: 1 << 6)
+    /// Include 8BIM (Photoshop) Metadata.
+    public static let eightBIM = MetadataOptions(rawValue: 1 << 7)
     /// Don't include any additional metadata types.
     public static let none: MetadataOptions = []
     /// Include all known metadata types.
-    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png, .gif]
+    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png, .gif, .eightBIM]
 }

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--8bim|eight-bim] [--no-8bim|no-eight-bim] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -83,6 +83,16 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-gif:**
 
 *Include GIF metadata.*
+
+
+**--8bim|eight-bim:**
+
+*Include 8BIM (Photoshop) metadata.*
+
+
+**--no-8bim|no-eight-bim:**
+
+*Include 8BIM (Photoshop) metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -4,7 +4,7 @@ import ImageMetadata
 import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps, dng, png, gif
+    case exif, iptc, tiff, gps, dng, png, gif, eightBIM
 }
 
 fileprivate extension MetadataType {
@@ -24,6 +24,8 @@ fileprivate extension MetadataType {
             return .png
         case .gif:
             return .gif
+        case .eightBIM:
+            return .eightBIM
         }
     }
 }
@@ -63,6 +65,9 @@ struct imgmd: ParsableCommand {
     @Flag(name: .long, inversion: .prefixedNo, help: "Include GIF metadata.")
     var gif: Bool = false
 
+    @Flag(name: [.customLong("8bim"), .customLong("eight-bim")], inversion: .prefixedNo, help: "Include 8BIM (Photoshop) metadata.")
+    var eightBIM: Bool = false
+
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
     
@@ -98,6 +103,7 @@ struct imgmd: ParsableCommand {
         if dng { metadataOptions.insert(.dng) }
         if png { metadataOptions.insert(.png) }
         if gif { metadataOptions.insert(.gif) }
+        if eightBIM { metadataOptions.insert(.eightBIM) }
 
         if basic {
             metadataOptions = MetadataOptions.none
@@ -116,6 +122,9 @@ struct imgmd: ParsableCommand {
                 }
                 if Self.conforms(url: url, to: .gif) {
                     options.insert(.gif)
+                }
+                if let psd = UTType("com.adobe.photoshop-image"), Self.conforms(url: url, to: psd) {
+                    options.insert(.eightBIM)
                 }
             }
             return try ImageMetadata(url: url, options: options)

--- a/Tests/ImageMetadataTests/EightBIMTests.swift
+++ b/Tests/ImageMetadataTests/EightBIMTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+import ImageIO
+@testable import ImageMetadata
+
+
+struct EightBIMTests {
+    static func sampleRaw8BIM() -> NSDictionary {
+        return [
+            kCGImageProperty8BIMLayerNames: ["Background", "Layer 1", "Adjustment"],
+            kCGImageProperty8BIMVersion: 1,
+        ]
+    }
+
+    let eightBIM: EightBIM
+
+    init() {
+        self.eightBIM = EightBIM(rawValue: Self.sampleRaw8BIM())
+    }
+
+    @Test func layerNames() {
+        #expect(eightBIM.layerNames == ["Background", "Layer 1", "Adjustment"])
+    }
+
+    @Test func version() {
+        #expect(eightBIM.version == 1)
+    }
+
+    @Test("Encoding emits present fields and omits nils")
+    func encoding() throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(eightBIM)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["layerNames"] as? [String] == ["Background", "Layer 1", "Adjustment"])
+        #expect(json["version"] as? Int == 1)
+    }
+
+    @Test("Missing or malformed values produce nils")
+    func missingOrMalformedValues() {
+        let raw: NSMutableDictionary = [
+            kCGImageProperty8BIMVersion: "not-an-int",
+        ]
+
+        let eightBIM = EightBIM(rawValue: raw)
+
+        #expect(eightBIM.layerNames == nil)
+        #expect(eightBIM.version == nil)
+    }
+
+    @Test("Empty dictionary produces an all-nil EightBIM that encodes to {}")
+    func emptyDictionary() throws {
+        let eightBIM = EightBIM(rawValue: [:])
+
+        #expect(eightBIM.layerNames == nil)
+        #expect(eightBIM.version == nil)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(eightBIM)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New `EightBIM` metadata type covering both [8BIM Image Properties](https://developer.apple.com/documentation/imageio/8bim-image-properties) keys: `layerNames` and `version`.
- Wires into `MetadataOptions.eightBIM` (bit 7) / `ImageMetadata.eightBIM` and the `imgmd` CLI (`--8bim` / `--no-8bim`, with `--eight-bim` as an alias). UTI auto-include kicks in for files conforming to `com.adobe.photoshop-image` (PSD).
- Adds 5 EightBIM tests covering parsing, encoding, malformed inputs, and an empty-dictionary case.

## Notes
- 8BIM (Photoshop image resource block) is not unique to PSD files — it's frequently embedded in JPEGs and TIFFs that Photoshop has touched. The UTI auto-include only covers the PSD case; for other files users pass `--8bim` explicitly.
- Naming: Swift identifiers can't start with a digit, so the type is `EightBIM` and the property/option is `eightBIM`. The CLI flag uses the more recognizable `--8bim` (and `--eight-bim` as an alternate).

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` — 356 tests pass (5 new in `EightBIMTests`).
- [ ] Spot-check `imgmd <some.psd>` and confirm the `eightBIM` block appears in JSON output.
- [ ] Spot-check `imgmd --8bim <some-photoshop-touched.jpg>` to confirm the explicit-flag path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)