### PR TITLE
Add HEIC metadata support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,19 +37,19 @@ The `ImageMetadata` target wraps the dictionary-based output of `CGImageSourceCo
 
 1. `ImageFile` validates a file URL (security-scoped access, content-type check against `.image`, file size).
 2. `ImageMetadata.init(url:options:)` → `init(imageFile:)` → `init(imageSource:)` → `init(rawValue: NSDictionary, options:)`. The `rawValue` initializer is the single ingestion point that pulls properties out of the ImageIO dictionary using `kCGImageProperty*` keys.
-3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`, `GIFDictionary`, `8BIMDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM` structs only when the matching `MetadataOptions` flag is set.
+3. Sub-dictionaries (`kCGImagePropertyExifDictionary`, `IPTCDictionary`, `TIFFDictionary`, `GPSDictionary`, `DNGDictionary`, `PNGDictionary`, `GIFDictionary`, `8BIMDictionary`, `HEICSDictionary`) are decoded into `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM`, `HEIC` structs only when the matching `MetadataOptions` flag is set.
 
-`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.gif`, `.eightBIM`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
+`MetadataOptions` is an `OptionSet` (`.exif`, `.iptc`, `.tiff`, `.gps`, `.dng`, `.png`, `.gif`, `.eightBIM`, `.heic`, `.all`, `.none`) that gates which sub-metadata blocks are populated. The CLI re-maps its `--exif/--no-exif` style flags onto this option set.
 
 ### The `Metadata` protocol
 
-Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes; `GIF` does the same with `imageColorMap`.
+Every public metadata type (`ImageMetadata`, `ImageFile`, `EXIF`, `IPTC`, `TIFF`, `GPS`, `DNG`, `PNG`, `GIF`, `EightBIM`, `HEIC`) conforms to `Metadata: Encodable & CustomStringConvertible & Sendable`. The protocol's default `description` JSON-encodes `self` with `.iso8601` dates, sorted keys, and pretty printing — that's what `imgmd` ultimately prints. Encoding behavior for each type is customized in dedicated `*+Encodable.swift` files; treat those as the source of truth for the JSON shape, not the stored properties. `DNG`'s encoder is intentionally lossy: large binary blobs (`originalRawFileData`, ICC profiles, opcode lists, `privateData`) and the linearization table are emitted as integer byte/entry counts rather than their raw bytes; `GIF` does the same with `imageColorMap`. The `HEIC` type wraps `kCGImagePropertyHEICSDictionary` (HEIC Sequence) — Apple's docs page is named "HEIC Image Properties" but the underlying constants are `HEICS`.
 
 ### Sub-metadata structure
 
 Each metadata family lives in its own folder and follows the same pattern:
 
-- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/`, `GIF/`, `EightBIM/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
+- `EXIF/`, `IPTC/`, `TIFF/`, `GPS/`, `DNG/`, `PNG/`, `GIF/`, `EightBIM/`, `HEIC/` — one struct per family plus an `*+Encodable.swift` and any enum types modeling EXIF's integer-coded fields (`ExposureMode`, `WhiteBalance`, `SceneCaptureType`, `LightSource`, etc., each `RawRepresentable<Int>`).
 - `GPS/GPS+CoreLocation.swift` provides interop with `CoreLocation`.
 - `Extensions/Calendar.swift`, `Extensions/TimeZone.swift` — date parsing helpers used to assemble `Date` values from EXIF's split `DateTime* + SubsecTime* + OffsetTime*` fields. Date assembly is subtle (see prior commit history around date parsing); when changing it, run `EXIFTests` and the root-level `CalendarTests.swift` to catch regressions.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ OPTIONS:
   --gif/--no-gif          Include GIF metadata. (default: --no-gif)
   --8bim, --eight-bim/--no-8bim, --no-eight-bim
                           Include 8BIM (Photoshop) metadata. (default: --no-8bim)
+  --heic/--no-heic        Include HEIC metadata. (default: --no-heic)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
 

--- a/Sources/ImageMetadata/HEIC/HEIC+Encodable.swift
+++ b/Sources/ImageMetadata/HEIC/HEIC+Encodable.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension HEIC: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case canvasPixelWidth
+        case canvasPixelHeight
+
+        case delayTime
+        case unclampedDelayTime
+        case loopCount
+        case frameInfoArray
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(canvasPixelWidth, forKey: .canvasPixelWidth)
+        try container.encodeIfPresent(canvasPixelHeight, forKey: .canvasPixelHeight)
+
+        try container.encodeIfPresent(delayTime, forKey: .delayTime)
+        try container.encodeIfPresent(unclampedDelayTime, forKey: .unclampedDelayTime)
+        try container.encodeIfPresent(loopCount, forKey: .loopCount)
+        try container.encodeIfPresent(frameInfoArray, forKey: .frameInfoArray)
+    }
+}

--- a/Sources/ImageMetadata/HEIC/HEIC.swift
+++ b/Sources/ImageMetadata/HEIC/HEIC.swift
@@ -1,0 +1,51 @@
+public import Foundation
+import ImageIO
+
+/// High Efficiency Image Coding (HEIC).
+///
+/// Keys mirror Apple's [HEIC Image Properties](https://developer.apple.com/documentation/imageio/heic-image-properties).
+/// Despite the docs page name, the underlying ImageIO constants are namespaced
+/// `HEICS` (HEIC Sequence) and primarily describe animated HEIC content.
+public struct HEIC: Metadata {
+
+    // MARK: - Canvas
+
+    /// Width of the logical canvas the frames composite onto.
+    public let canvasPixelWidth: Int?
+
+    /// Height of the logical canvas the frames composite onto.
+    public let canvasPixelHeight: Int?
+
+    // MARK: - Animation
+
+    /// The clamped frame delay in seconds. See ``unclampedDelayTime`` for the
+    /// original value before any browser-side clamping.
+    public let delayTime: Double?
+
+    /// The original frame delay in seconds, before any browser-side clamping.
+    public let unclampedDelayTime: Double?
+
+    /// The number of times the animation should loop. `0` means infinite.
+    public let loopCount: Int?
+
+    /// Stringified per-frame metadata dictionaries. The exact keys aren't
+    /// publicly documented, so each frame is represented as a single string.
+    public let frameInfoArray: [String]?
+
+    // MARK: - Initialization
+
+    public init(rawValue: NSDictionary) {
+        self.canvasPixelWidth = rawValue[kCGImagePropertyHEICSCanvasPixelWidth] as? Int
+        self.canvasPixelHeight = rawValue[kCGImagePropertyHEICSCanvasPixelHeight] as? Int
+
+        self.delayTime = rawValue[kCGImagePropertyHEICSDelayTime] as? Double
+        self.unclampedDelayTime = rawValue[kCGImagePropertyHEICSUnclampedDelayTime] as? Double
+        self.loopCount = rawValue[kCGImagePropertyHEICSLoopCount] as? Int
+
+        if let frames = rawValue[kCGImagePropertyHEICSFrameInfoArray] as? [Any] {
+            self.frameInfoArray = frames.compactMap(Self.describe)
+        } else {
+            self.frameInfoArray = nil
+        }
+    }
+}

--- a/Sources/ImageMetadata/ImageMetadata+Encodable.swift
+++ b/Sources/ImageMetadata/ImageMetadata+Encodable.swift
@@ -24,6 +24,7 @@ extension ImageMetadata: Encodable {
         case png
         case gif
         case eightBIM
+        case heic
         case imageFile = "file"
     }
     
@@ -75,6 +76,10 @@ extension ImageMetadata: Encodable {
 
         if options.contains(.eightBIM) {
             try container.encodeIfPresent(eightBIM, forKey: .eightBIM)
+        }
+
+        if options.contains(.heic) {
+            try container.encodeIfPresent(heic, forKey: .heic)
         }
 
         if let imageFile {

--- a/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
+++ b/Sources/ImageMetadata/ImageMetadata.docc/ImageMetadata.md
@@ -29,6 +29,7 @@ See <doc:Usage>.
 - ``PNG``
 - ``GIF``
 - ``EightBIM``
+- ``HEIC``
 
 ### Creating an `ImageMetadata` type.
 

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -80,6 +80,9 @@ public struct ImageMetadata: Metadata {
     /// PSD files but also embedded in JPEGs and TIFFs touched by Photoshop.
     public let eightBIM: EightBIM?
 
+    /// Metadata for High Efficiency Image Coding (HEIC) sequences (animated HEIC).
+    public let heic: HEIC?
+
     public private(set) var imageFile: ImageFile?
     
 
@@ -169,6 +172,12 @@ public struct ImageMetadata: Metadata {
             self.eightBIM = EightBIM(rawValue: eightBIMDictionary)
         } else {
             self.eightBIM = nil
+        }
+
+        if options.contains(.heic), let heicDictionary = rawValue[kCGImagePropertyHEICSDictionary] as? NSDictionary {
+            self.heic = HEIC(rawValue: heicDictionary)
+        } else {
+            self.heic = nil
         }
 
         // Defaults that may be updated in other initializers

--- a/Sources/ImageMetadata/MetadataOptions.swift
+++ b/Sources/ImageMetadata/MetadataOptions.swift
@@ -22,8 +22,10 @@ public struct MetadataOptions: OptionSet, Sendable {
     public static let gif  = MetadataOptions(rawValue: 1 << 6)
     /// Include 8BIM (Photoshop) Metadata.
     public static let eightBIM = MetadataOptions(rawValue: 1 << 7)
+    /// Include HEIC Metadata.
+    public static let heic = MetadataOptions(rawValue: 1 << 8)
     /// Don't include any additional metadata types.
     public static let none: MetadataOptions = []
     /// Include all known metadata types.
-    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png, .gif, .eightBIM]
+    public static let all: MetadataOptions = [.exif, .iptc, .tiff, .gps, .dng, .png, .gif, .eightBIM, .heic]
 }

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--8bim|eight-bim] [--no-8bim|no-eight-bim] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--8bim|eight-bim] [--no-8bim|no-eight-bim] [--heic] [--no-heic] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -93,6 +93,16 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-8bim|no-eight-bim:**
 
 *Include 8BIM (Photoshop) metadata.*
+
+
+**--heic:**
+
+*Include HEIC metadata.*
+
+
+**--no-heic:**
+
+*Include HEIC metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -4,7 +4,7 @@ import ImageMetadata
 import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps, dng, png, gif, eightBIM
+    case exif, iptc, tiff, gps, dng, png, gif, eightBIM, heic
 }
 
 fileprivate extension MetadataType {
@@ -26,6 +26,8 @@ fileprivate extension MetadataType {
             return .gif
         case .eightBIM:
             return .eightBIM
+        case .heic:
+            return .heic
         }
     }
 }
@@ -68,6 +70,9 @@ struct imgmd: ParsableCommand {
     @Flag(name: [.customLong("8bim"), .customLong("eight-bim")], inversion: .prefixedNo, help: "Include 8BIM (Photoshop) metadata.")
     var eightBIM: Bool = false
 
+    @Flag(name: .long, inversion: .prefixedNo, help: "Include HEIC metadata.")
+    var heic: Bool = false
+
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
     
@@ -104,6 +109,7 @@ struct imgmd: ParsableCommand {
         if png { metadataOptions.insert(.png) }
         if gif { metadataOptions.insert(.gif) }
         if eightBIM { metadataOptions.insert(.eightBIM) }
+        if heic { metadataOptions.insert(.heic) }
 
         if basic {
             metadataOptions = MetadataOptions.none
@@ -125,6 +131,9 @@ struct imgmd: ParsableCommand {
                 }
                 if let psd = UTType("com.adobe.photoshop-image"), Self.conforms(url: url, to: psd) {
                     options.insert(.eightBIM)
+                }
+                if Self.conforms(url: url, to: .heic) || Self.conforms(url: url, to: .heics) {
+                    options.insert(.heic)
                 }
             }
             return try ImageMetadata(url: url, options: options)

--- a/Tests/ImageMetadataTests/HEICTests.swift
+++ b/Tests/ImageMetadataTests/HEICTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+import ImageIO
+@testable import ImageMetadata
+
+
+struct HEICTests {
+    static func sampleRawHEIC() -> NSDictionary {
+        return [
+            kCGImagePropertyHEICSCanvasPixelWidth: 1920,
+            kCGImagePropertyHEICSCanvasPixelHeight: 1080,
+            kCGImagePropertyHEICSDelayTime: 0.04,
+            kCGImagePropertyHEICSUnclampedDelayTime: 0.0333,
+            kCGImagePropertyHEICSLoopCount: 0,
+            kCGImagePropertyHEICSFrameInfoArray: [
+                ["delay": 0.04] as NSDictionary,
+                ["delay": 0.04] as NSDictionary,
+            ],
+        ]
+    }
+
+    let heic: HEIC
+
+    init() {
+        self.heic = HEIC(rawValue: Self.sampleRawHEIC())
+    }
+
+    // MARK: - Canvas
+
+    @Test func canvasPixelWidth() {
+        #expect(heic.canvasPixelWidth == 1920)
+    }
+
+    @Test func canvasPixelHeight() {
+        #expect(heic.canvasPixelHeight == 1080)
+    }
+
+    // MARK: - Animation
+
+    @Test func delayTime() {
+        #expect(heic.delayTime == 0.04)
+    }
+
+    @Test func unclampedDelayTime() {
+        #expect(heic.unclampedDelayTime == 0.0333)
+    }
+
+    @Test func loopCount() {
+        #expect(heic.loopCount == 0)
+    }
+
+    @Test func frameInfoArray() {
+        #expect(heic.frameInfoArray?.count == 2)
+    }
+
+    // MARK: - Encoding
+
+    @Test("Encoding emits present fields and omits nils")
+    func encoding() throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(heic)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["canvasPixelWidth"] as? Int == 1920)
+        #expect(json["canvasPixelHeight"] as? Int == 1080)
+        #expect(json["delayTime"] as? Double == 0.04)
+        #expect(json["unclampedDelayTime"] as? Double == 0.0333)
+        #expect(json["loopCount"] as? Int == 0)
+        #expect((json["frameInfoArray"] as? [String])?.count == 2)
+    }
+
+    @Test("Missing or malformed values produce nils")
+    func missingOrMalformedValues() {
+        let raw = Self.sampleRawHEIC().mutableCopy() as! NSMutableDictionary
+        raw[kCGImagePropertyHEICSDelayTime] = "not-a-double"
+        raw[kCGImagePropertyHEICSLoopCount] = NSNull()
+        raw.removeObject(forKey: kCGImagePropertyHEICSCanvasPixelWidth)
+        raw.removeObject(forKey: kCGImagePropertyHEICSFrameInfoArray)
+
+        let heic = HEIC(rawValue: raw)
+
+        #expect(heic.delayTime == nil)
+        #expect(heic.loopCount == nil)
+        #expect(heic.canvasPixelWidth == nil)
+        #expect(heic.frameInfoArray == nil)
+    }
+
+    @Test("Empty dictionary produces an all-nil HEIC that encodes to {}")
+    func emptyDictionary() throws {
+        let heic = HEIC(rawValue: [:])
+
+        #expect(heic.canvasPixelWidth == nil)
+        #expect(heic.delayTime == nil)
+        #expect(heic.frameInfoArray == nil)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(heic)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New `HEIC` metadata type covering every key in [HEIC Image Properties](https://developer.apple.com/documentation/imageio/heic-image-properties): canvas (`canvasPixelWidth` / `canvasPixelHeight`) and animation (`delayTime`, `unclampedDelayTime`, `loopCount`, `frameInfoArray`).
- Wires into `MetadataOptions.heic` (bit 8) / `ImageMetadata.heic` and the `imgmd` CLI (`--heic` / `--no-heic`, plus UTI-based auto-include for files conforming to `UTType.heic` or `UTType.heics`).
- Adds 9 HEIC tests covering each field, encoding, malformed inputs, and an empty-dictionary case.

## Notes
- Naming wrinkle: the type is `HEIC` (matching Apple's docs page name and user expectations), but the underlying ImageIO constants are namespaced `HEICS` (HEIC Sequence). The keys are animation-focused, so for static HEIC files the dictionary will likely be nil/missing. Documented in the `HEIC.swift` doc comment.
- `frameInfoArray` is typed as `[String]?` (each frame stringified via the shared `describe` helper), same pattern as `GIF.frameInfoArray`. Per-frame dict shape isn't publicly documented.
- `--heic` is long-only (the short `-h` is taken by `--help`).

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` — 365 tests pass (9 new in `HEICTests`).
- [ ] Spot-check `imgmd <some.heic>` and confirm the `heic` block appears in JSON output (likely empty for static HEIC).
- [ ] Spot-check `imgmd <some.heics>` (animated) and confirm canvas/loopCount/frameInfoArray come through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)