### PR TITLE
Tighten test idioms in metadata suites

### DIFF
--- a/Tests/ImageMetadataTests/DNGTests.swift
+++ b/Tests/ImageMetadataTests/DNGTests.swift
@@ -368,7 +368,7 @@ struct DNGTests {
 
     @Test("previewDateTime falls back to EXIF YYYY:MM:DD HH:MM:SS form")
     func previewDateTimeExifFallback() throws {
-        let raw = Self.sampleRawDNG().mutableCopy() as! NSMutableDictionary
+        let raw = try #require(Self.sampleRawDNG().mutableCopy() as? NSMutableDictionary)
         raw[kCGImagePropertyDNGPreviewDateTime] = "2025:02:13 15:34:57"
 
         let dng = DNG(rawValue: raw)
@@ -459,8 +459,8 @@ struct DNGTests {
     }
 
     @Test("Missing or malformed values produce nils")
-    func missingOrMalformedValues() {
-        let raw = Self.sampleRawDNG().mutableCopy() as! NSMutableDictionary
+    func missingOrMalformedValues() throws {
+        let raw = try #require(Self.sampleRawDNG().mutableCopy() as? NSMutableDictionary)
         raw[kCGImagePropertyDNGBaselineExposure] = "not-a-double"
         raw[kCGImagePropertyDNGBayerGreenSplit] = NSNull()
         raw[kCGImagePropertyDNGPreviewDateTime] = "garbage"

--- a/Tests/ImageMetadataTests/GIFTests.swift
+++ b/Tests/ImageMetadataTests/GIFTests.swift
@@ -83,12 +83,13 @@ struct GIFTests {
         // Replaced with byte count.
         #expect(json["imageColorMap"] as? Int == 768)
         // Stringified frame entries.
-        #expect((json["frameInfoArray"] as? [String])?.count == 3)
+        let frames = try #require(json["frameInfoArray"] as? [String])
+        #expect(frames.count == 3)
     }
 
     @Test("Missing or malformed values produce nils")
-    func missingOrMalformedValues() {
-        let raw = Self.sampleRawGIF().mutableCopy() as! NSMutableDictionary
+    func missingOrMalformedValues() throws {
+        let raw = try #require(Self.sampleRawGIF().mutableCopy() as? NSMutableDictionary)
         raw[kCGImagePropertyGIFDelayTime] = "not-a-double"
         raw[kCGImagePropertyGIFLoopCount] = NSNull()
         raw.removeObject(forKey: kCGImagePropertyGIFCanvasPixelWidth)

--- a/Tests/ImageMetadataTests/HEICTests.swift
+++ b/Tests/ImageMetadataTests/HEICTests.swift
@@ -66,12 +66,14 @@ struct HEICTests {
         #expect(json["delayTime"] as? Double == 0.04)
         #expect(json["unclampedDelayTime"] as? Double == 0.0333)
         #expect(json["loopCount"] as? Int == 0)
-        #expect((json["frameInfoArray"] as? [String])?.count == 2)
+
+        let frames = try #require(json["frameInfoArray"] as? [String])
+        #expect(frames.count == 2)
     }
 
     @Test("Missing or malformed values produce nils")
-    func missingOrMalformedValues() {
-        let raw = Self.sampleRawHEIC().mutableCopy() as! NSMutableDictionary
+    func missingOrMalformedValues() throws {
+        let raw = try #require(Self.sampleRawHEIC().mutableCopy() as? NSMutableDictionary)
         raw[kCGImagePropertyHEICSDelayTime] = "not-a-double"
         raw[kCGImagePropertyHEICSLoopCount] = NSNull()
         raw.removeObject(forKey: kCGImagePropertyHEICSCanvasPixelWidth)

--- a/Tests/ImageMetadataTests/MetadataHelpersTests.swift
+++ b/Tests/ImageMetadataTests/MetadataHelpersTests.swift
@@ -11,14 +11,15 @@ struct MetadataHelpersTests {
 
     // MARK: - intArray
 
-    @Test("intArray returns nil for nil input")
-    func intArrayNil() {
-        #expect(TestMetadata.intArray(nil) == nil)
-    }
-
-    @Test("intArray returns nil for NSNull")
-    func intArrayNSNull() {
-        #expect(TestMetadata.intArray(NSNull()) == nil)
+    @Test("intArray returns nil for non-array or wrong-element inputs", arguments: [
+        nil as (any Sendable)?,
+        NSNull(),
+        "not an array",
+        42,
+        ["1", "2"],
+    ])
+    func intArrayReturnsNil(input: (any Sendable)?) {
+        #expect(TestMetadata.intArray(input) == nil)
     }
 
     @Test("intArray passes through a native [Int]")
@@ -44,27 +45,16 @@ struct MetadataHelpersTests {
         #expect(TestMetadata.intArray([] as [NSNumber]) == [])
     }
 
-    @Test("intArray returns nil for non-array input")
-    func intArrayWrongType() {
-        #expect(TestMetadata.intArray("not an array") == nil)
-        #expect(TestMetadata.intArray(42) == nil)
-    }
-
-    @Test("intArray returns nil for [String]")
-    func intArrayWrongElementType() {
-        #expect(TestMetadata.intArray(["1", "2"]) == nil)
-    }
-
     // MARK: - doubleArray
 
-    @Test("doubleArray returns nil for nil input")
-    func doubleArrayNil() {
-        #expect(TestMetadata.doubleArray(nil) == nil)
-    }
-
-    @Test("doubleArray returns nil for NSNull")
-    func doubleArrayNSNull() {
-        #expect(TestMetadata.doubleArray(NSNull()) == nil)
+    @Test("doubleArray returns nil for non-array inputs", arguments: [
+        nil as (any Sendable)?,
+        NSNull(),
+        "not an array",
+        3.14,
+    ])
+    func doubleArrayReturnsNil(input: (any Sendable)?) {
+        #expect(TestMetadata.doubleArray(input) == nil)
     }
 
     @Test("doubleArray passes through a native [Double]")
@@ -90,22 +80,14 @@ struct MetadataHelpersTests {
         #expect(TestMetadata.doubleArray([] as [NSNumber]) == [])
     }
 
-    @Test("doubleArray returns nil for non-array input")
-    func doubleArrayWrongType() {
-        #expect(TestMetadata.doubleArray("not an array") == nil)
-        #expect(TestMetadata.doubleArray(3.14) == nil)
-    }
-
     // MARK: - describe
 
-    @Test("describe returns nil for nil input")
-    func describeNil() {
-        #expect(TestMetadata.describe(nil) == nil)
-    }
-
-    @Test("describe returns nil for NSNull")
-    func describeNSNull() {
-        #expect(TestMetadata.describe(NSNull()) == nil)
+    @Test("describe returns nil for nil or NSNull", arguments: [
+        nil as (any Sendable)?,
+        NSNull(),
+    ])
+    func describeReturnsNil(input: (any Sendable)?) {
+        #expect(TestMetadata.describe(input) == nil)
     }
 
     @Test("describe stringifies common scalar values")

--- a/Tests/ImageMetadataTests/PNGTests.swift
+++ b/Tests/ImageMetadataTests/PNGTests.swift
@@ -173,8 +173,8 @@ struct PNGTests {
     }
 
     @Test("Missing or malformed values produce nils")
-    func missingOrMalformedValues() {
-        let raw = Self.sampleRawPNG().mutableCopy() as! NSMutableDictionary
+    func missingOrMalformedValues() throws {
+        let raw = try #require(Self.sampleRawPNG().mutableCopy() as? NSMutableDictionary)
         raw[kCGImagePropertyPNGGamma] = "not-a-double"
         raw[kCGImagePropertyPNGCreationTime] = "garbage"
         raw[kCGImagePropertyPNGsRGBIntent] = NSNull()


### PR DESCRIPTION
## Summary
Cleanup pass on the metadata test suites surfaced by a Swift Testing review:

- **Parameterize the "returns nil" cases in `MetadataHelpersTests`.** Collapses nine individual `@Test` methods (`intArray` nil/NSNull/wrong-type/wrong-element, `doubleArray` nil/NSNull/wrong-type, `describe` nil/NSNull) into three parameterized tests. Argument arrays are typed as `[(any Sendable)?]` because Swift Testing requires argument elements to be `Sendable` — `Any?` doesn't conform.
- **Replace `mutableCopy() as! NSMutableDictionary` with `try #require`** in the malformed-input tests across `DNGTests`, `PNGTests`, `GIFTests`, and `HEICTests`. Idiomatic replacement for force-unwraps in Swift Testing — gives a clean test failure if the cast ever breaks instead of a fatal error.
- **Lift the `[String]` cast** out in the HEIC and GIF encoding tests so a failed cast points at the cast itself instead of an opaque `nil == 2` style comparison.

## Notes
- `EightBIMTests` constructed its mutable dictionary directly so didn't need the `as!` fix.
- `TIFFTests` has the same `mutableCopy() as!` pattern but predates this work, so leaving it untouched per Swift Testing skill guidance ("don't apply new conventions to existing tests without permission").

## Test plan
- [x] `swift build` is clean.
- [x] `swift test` — 359 tests pass (count drops from 365 because the three parameterized "returns nil" tests collapse nine individual tests; all argument iterations still run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)