### PR TITLE
Fix ExifAux dictionary lookup

### DIFF
--- a/Sources/ImageMetadata/EXIF/EXIF.swift
+++ b/Sources/ImageMetadata/EXIF/EXIF.swift
@@ -304,7 +304,7 @@ public struct EXIF: Metadata {
     /// The white balance mode.
     public let whiteBalance: EXIF.WhiteBalance?
     
-    public init(rawValue: NSDictionary) {
+    public init(rawValue: NSDictionary, aux: NSDictionary? = nil) {
         self.apertureValue = rawValue[kCGImagePropertyExifApertureValue] as? Double
         self.bodySerialNumber = rawValue[kCGImagePropertyExifBodySerialNumber] as? String
         self.brightnessValue = rawValue[kCGImagePropertyExifBrightnessValue] as? Double
@@ -463,10 +463,10 @@ public struct EXIF: Metadata {
         self.whiteBalance = (rawValue[kCGImagePropertyExifWhiteBalance] as? Int)
             .map({ EXIF.WhiteBalance(rawValue: $0) }) ?? nil
         
-        // Auxiliary (ExifAux) fields
-        
-        let aux = rawValue[kCGImagePropertyExifAuxDictionary] as? NSDictionary
-        
+        // Auxiliary (ExifAux) fields. The ExifAux dictionary lives at the
+        // top level alongside the EXIF dictionary, not nested inside it, so
+        // it must be passed in separately.
+
         self.firmware = aux?[kCGImagePropertyExifAuxFirmware] as? String
         self.flashCompensation = aux?[kCGImagePropertyExifAuxFlashCompensation] as? String
         self.imageNumber = aux?[kCGImagePropertyExifAuxImageNumber] as? String

--- a/Sources/ImageMetadata/ImageMetadata.swift
+++ b/Sources/ImageMetadata/ImageMetadata.swift
@@ -127,7 +127,8 @@ public struct ImageMetadata: Metadata {
         self.pixelWidth = rawValue[kCGImagePropertyPixelWidth] as? Int
                 
         if options.contains(.exif), let exifDictionary = rawValue[kCGImagePropertyExifDictionary] as? NSDictionary {
-            self.exif = EXIF(rawValue: exifDictionary)
+            let auxDictionary = rawValue[kCGImagePropertyExifAuxDictionary] as? NSDictionary
+            self.exif = EXIF(rawValue: exifDictionary, aux: auxDictionary)
         } else {
             self.exif = nil
         }

--- a/Tests/ImageMetadataTests/EXIFTests.swift
+++ b/Tests/ImageMetadataTests/EXIFTests.swift
@@ -547,14 +547,12 @@ struct EXIFTests {
     }
 
     @Test func auxiliaryDictionary_lensModelAndSerialNumberFromAux() {
-        let dict: NSDictionary = [
-            kCGImagePropertyExifAuxDictionary as String: [
-                kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model",
-                kCGImagePropertyExifAuxLensSerialNumber as String: "AUX12345"
-            ] as NSDictionary
+        let aux: NSDictionary = [
+            kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model",
+            kCGImagePropertyExifAuxLensSerialNumber as String: "AUX12345"
         ]
-        let exif = EXIF(rawValue: dict)
-        
+        let exif = EXIF(rawValue: [:], aux: aux)
+
         #expect(exif.lensModel == "AUX Lens Model")
         #expect(exif.lensSerialNumber == "AUX12345")
     }
@@ -565,7 +563,7 @@ struct EXIFTests {
             kCGImagePropertyExifLensSerialNumber as String: "MAIN67890"
         ]
         let exif = EXIF(rawValue: dict)
-        
+
         #expect(exif.lensModel == "Main Lens Model")
         #expect(exif.lensSerialNumber == "MAIN67890")
     }
@@ -573,29 +571,27 @@ struct EXIFTests {
     @Test func auxiliaryDictionary_auxTakesPrecedenceOverMain() {
         let dict: NSDictionary = [
             kCGImagePropertyExifLensModel as String: "Main Lens Model",
-            kCGImagePropertyExifAuxDictionary as String: [
-                kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model"
-            ] as NSDictionary
         ]
-        let exif = EXIF(rawValue: dict)
-        
+        let aux: NSDictionary = [
+            kCGImagePropertyExifAuxLensModel as String: "AUX Lens Model"
+        ]
+        let exif = EXIF(rawValue: dict, aux: aux)
+
         #expect(exif.lensModel == "AUX Lens Model")
     }
 
     @Test func auxiliaryDictionary_allAuxProperties() {
-        let dict: NSDictionary = [
-            kCGImagePropertyExifAuxDictionary as String: [
-                kCGImagePropertyExifAuxFirmware as String: "v1.2.3",
-                kCGImagePropertyExifAuxFlashCompensation as String: "+0.5",
-                kCGImagePropertyExifAuxImageNumber as String: "IMG_1234",
-                kCGImagePropertyExifAuxLensID as String: "LENS001",
-                kCGImagePropertyExifAuxLensInfo as String: "24-70mm f/2.8",
-                kCGImagePropertyExifAuxOwnerName as String: "John Doe",
-                kCGImagePropertyExifAuxSerialNumber as String: "SN123456"
-            ] as NSDictionary
+        let aux: NSDictionary = [
+            kCGImagePropertyExifAuxFirmware as String: "v1.2.3",
+            kCGImagePropertyExifAuxFlashCompensation as String: "+0.5",
+            kCGImagePropertyExifAuxImageNumber as String: "IMG_1234",
+            kCGImagePropertyExifAuxLensID as String: "LENS001",
+            kCGImagePropertyExifAuxLensInfo as String: "24-70mm f/2.8",
+            kCGImagePropertyExifAuxOwnerName as String: "John Doe",
+            kCGImagePropertyExifAuxSerialNumber as String: "SN123456"
         ]
-        let exif = EXIF(rawValue: dict)
-        
+        let exif = EXIF(rawValue: [:], aux: aux)
+
         #expect(exif.firmware == "v1.2.3")
         #expect(exif.flashCompensation == "+0.5")
         #expect(exif.imageNumber == "IMG_1234")


### PR DESCRIPTION
## Summary
The ExifAux dictionary lives at the top level alongside the EXIF dictionary, **not nested inside it**:

\`\`\`
top-level properties
├── kCGImagePropertyExifDictionary       ← what EXIF.init currently receives
└── kCGImagePropertyExifAuxDictionary    ← sibling, not child
\`\`\`

The existing lookup at \`EXIF.swift:468\` reads \`rawValue[kCGImagePropertyExifAuxDictionary]\` from \`rawValue\`, but \`rawValue\` is the inner EXIF dict, so the result is always \`nil\`. Every aux-derived field — \`firmware\`, \`flashCompensation\`, \`imageNumber\`, \`lensID\`, \`lensInfo\`, \`ownerName\`, \`serialNumber\`, plus the \`lensModel\` / \`lensSerialNumber\` fallbacks — was silently nil for real images.

The fix:
- Add an \`aux: NSDictionary? = nil\` parameter to \`EXIF.init\` (default preserves source compatibility).
- Have \`ImageMetadata.init\` extract the ExifAux dict from the top-level properties and pass it alongside the EXIF dict.
- Update the existing aux tests — they had been constructing dicts in the wrong shape (matching the bug, not ImageIO's actual output). Tests still exercise the same fallback semantics with the correct shape.

## Test plan
- [x] \`swift build\` is clean.
- [x] \`swift test\` — 359 tests pass.
- [ ] Spot-check on a real image with lens / firmware metadata to confirm the aux fields populate (likely a recent camera JPEG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)