### PR TITLE
Drop format-specific CLI flags; flip cross-format defaults to on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,10 @@ Each metadata family lives in its own folder and follows the same pattern:
 ### CLI (`imgmd`)
 
 `Sources/imgmd/imgmd.swift` is a single `ParsableCommand`. The flag-to-option mapping lives in `run()`:
-- `--basic` forces `MetadataOptions.none`.
+- The CLI exposes flags only for cross-format namespaces: `--exif`, `--iptc`, `--tiff`, `--gps`. Format-specific namespaces (DNG, PNG, GIF, HEIC, JFIF, WebP, 8BIM) have no flags — they're auto-included via UTI matching when the input file's content type conforms to a known format. UTI lookup uses `URL.resourceValues(forKeys: [.contentTypeKey])`.
+- 8BIM is auto-included for PSD, JPEG, and TIFF (Photoshop embeds 8BIM blocks in those formats).
+- `--basic` forces `MetadataOptions.none` and suppresses the auto-include path entirely.
 - If no metadata flag is set, defaults to `.all`.
-- For each input file the CLI also auto-adds `.dng` to that file's options when its UTI conforms to `UTType.dng` (looked up via `URL.resourceValues(forKeys: [.contentTypeKey])`). `--basic` suppresses this auto-include.
 - `--debug` short-circuits to printing the raw ImageIO dictionary via `ImageMetadata.getProperties(url:)`.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -71,27 +71,21 @@ OVERVIEW: Outputs metadata from the supplied image files as JSON.
 All metadata is output by default. Use the options to limit what metadata is
 displayed.
 
-USAGE: imgmd [<options>] [<files> ...]
+USAGE: imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--debug] [<files> ...]
 
 ARGUMENTS:
   <files>                 Image files.
 
 OPTIONS:
   -b, --basic             Basic. Don't include other metadata.
-  -e, --exif/--no-exif    Include EXIF metadata. (default: --no-exif)
-  -g, --gps/--no-gps      Include GPS metadata. (default: --no-gps)
-  -i, --iptc/--no-iptc    Include IPTC metadata. (default: --no-iptc)
-  -t, --tiff/--no-tiff    Include TIFF metadata. (default: --no-tiff)
-  --dng/--no-dng          Include DNG metadata. (default: --no-dng)
-  -p, --png/--no-png      Include PNG metadata. (default: --no-png)
-  --gif/--no-gif          Include GIF metadata. (default: --no-gif)
-  --8bim, --eight-bim/--no-8bim, --no-eight-bim
-                          Include 8BIM (Photoshop) metadata. (default: --no-8bim)
-  --heic/--no-heic        Include HEIC metadata. (default: --no-heic)
-  --jfif/--no-jfif        Include JFIF metadata. (default: --no-jfif)
-  --webp/--no-webp        Include WebP metadata. (default: --no-webp)
+  -e, --exif/--no-exif    Include EXIF metadata. (default: --exif)
+  -g, --gps/--no-gps      Include GPS metadata. (default: --gps)
+  -i, --iptc/--no-iptc    Include IPTC metadata. (default: --iptc)
+  -t, --tiff/--no-tiff    Include TIFF metadata. (default: --tiff)
   -d, --debug             Show the raw metadata.
   -h, --help              Show help information.
+
+Format-specific metadata (DNG, PNG, GIF, HEIC, JFIF, WebP, 8BIM) is auto-included when the file's content type matches. 8BIM is also auto-included for JPEG and TIFF files (where Photoshop often embeds it).
 
 Program ended with exit code: 0
 ```sh

--- a/Sources/imgmd/imgmd.docc/imgmd.md
+++ b/Sources/imgmd/imgmd.docc/imgmd.md
@@ -5,7 +5,7 @@
 Outputs metadata from the supplied image files as JSON.
 
 ```
-imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--dng] [--no-dng] [--png] [--no-png] [--gif] [--no-gif] [--8bim|eight-bim] [--no-8bim|no-eight-bim] [--heic] [--no-heic] [--jfif] [--no-jfif] [--webp] [--no-webp] [--debug] [<files>...] [--help]
+imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--debug] [<files>...] [--help]
 ```
 
 All metadata is output by default. Use the options to limit what metadata is displayed.
@@ -53,76 +53,6 @@ All metadata is output by default. Use the options to limit what metadata is dis
 **--no-tiff:**
 
 *Include TIFF metadata.*
-
-
-**--dng:**
-
-*Include DNG metadata.*
-
-
-**--no-dng:**
-
-*Include DNG metadata.*
-
-
-**--png:**
-
-*Include PNG metadata.*
-
-
-**--no-png:**
-
-*Include PNG metadata.*
-
-
-**--gif:**
-
-*Include GIF metadata.*
-
-
-**--no-gif:**
-
-*Include GIF metadata.*
-
-
-**--8bim|eight-bim:**
-
-*Include 8BIM (Photoshop) metadata.*
-
-
-**--no-8bim|no-eight-bim:**
-
-*Include 8BIM (Photoshop) metadata.*
-
-
-**--heic:**
-
-*Include HEIC metadata.*
-
-
-**--no-heic:**
-
-*Include HEIC metadata.*
-
-
-**--jfif:**
-
-*Include JFIF metadata.*
-
-
-**--no-jfif:**
-
-*Include JFIF metadata.*
-
-
-**--webp:**
-
-*Include WebP metadata.*
-
-
-**--no-webp:**
-
-*Include WebP metadata.*
 
 
 **--debug:**

--- a/Sources/imgmd/imgmd.swift
+++ b/Sources/imgmd/imgmd.swift
@@ -4,7 +4,7 @@ import ImageMetadata
 import UniformTypeIdentifiers
 
 fileprivate enum MetadataType: String, EnumerableFlag {
-    case exif, iptc, tiff, gps, dng, png, gif, eightBIM, heic, jfif, webP
+    case exif, iptc, tiff, gps
 }
 
 fileprivate extension MetadataType {
@@ -18,20 +18,6 @@ fileprivate extension MetadataType {
             return .tiff
         case .gps:
             return .gps
-        case .dng:
-            return .dng
-        case .png:
-            return .png
-        case .gif:
-            return .gif
-        case .eightBIM:
-            return .eightBIM
-        case .heic:
-            return .heic
-        case .jfif:
-            return .jfif
-        case .webP:
-            return .webP
         }
     }
 }
@@ -51,37 +37,16 @@ struct imgmd: ParsableCommand {
     var basic: Bool = false
     
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include EXIF metadata.")
-    var exif: Bool = false
-    
+    var exif: Bool = true
+
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include GPS metadata.")
-    var gps: Bool = false
-    
+    var gps: Bool = true
+
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include IPTC metadata.")
-    var iptc: Bool = false
-    
+    var iptc: Bool = true
+
     @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include TIFF metadata.")
-    var tiff: Bool = false
-
-    @Flag(name: .long, inversion: .prefixedNo, help: "Include DNG metadata.")
-    var dng: Bool = false
-
-    @Flag(name: .shortAndLong, inversion: .prefixedNo, help: "Include PNG metadata.")
-    var png: Bool = false
-
-    @Flag(name: .long, inversion: .prefixedNo, help: "Include GIF metadata.")
-    var gif: Bool = false
-
-    @Flag(name: [.customLong("8bim"), .customLong("eight-bim")], inversion: .prefixedNo, help: "Include 8BIM (Photoshop) metadata.")
-    var eightBIM: Bool = false
-
-    @Flag(name: .long, inversion: .prefixedNo, help: "Include HEIC metadata.")
-    var heic: Bool = false
-
-    @Flag(name: .long, inversion: .prefixedNo, help: "Include JFIF metadata.")
-    var jfif: Bool = false
-
-    @Flag(name: .customLong("webp"), inversion: .prefixedNo, help: "Include WebP metadata.")
-    var webP: Bool = false
+    var tiff: Bool = true
 
     @Flag(name: .shortAndLong, help: "Show the raw metadata.")
     var debug: Bool = false
@@ -115,18 +80,9 @@ struct imgmd: ParsableCommand {
         if iptc { metadataOptions.insert(.iptc) }
         if tiff { metadataOptions.insert(.tiff) }
         if gps { metadataOptions.insert(.gps) }
-        if dng { metadataOptions.insert(.dng) }
-        if png { metadataOptions.insert(.png) }
-        if gif { metadataOptions.insert(.gif) }
-        if eightBIM { metadataOptions.insert(.eightBIM) }
-        if heic { metadataOptions.insert(.heic) }
-        if jfif { metadataOptions.insert(.jfif) }
-        if webP { metadataOptions.insert(.webP) }
 
         if basic {
             metadataOptions = MetadataOptions.none
-        } else if metadataOptions.isEmpty {
-            metadataOptions = MetadataOptions.all
         }
 
         let imagesMetadata = try files.map { url -> ImageMetadata in
@@ -140,6 +96,11 @@ struct imgmd: ParsableCommand {
                 }
                 if Self.conforms(url: url, to: .gif) {
                     options.insert(.gif)
+                }
+                // 8BIM blocks live in PSD, but Photoshop also embeds them in
+                // JPEGs and TIFFs it has touched.
+                if Self.conforms(url: url, to: .jpeg) || Self.conforms(url: url, to: .tiff) {
+                    options.insert(.eightBIM)
                 }
                 if let psd = UTType("com.adobe.photoshop-image"), Self.conforms(url: url, to: psd) {
                     options.insert(.eightBIM)

--- a/Tests/imgmdTests/imgmdTests.swift
+++ b/Tests/imgmdTests/imgmdTests.swift
@@ -53,95 +53,99 @@ struct imgmdTests {
         #expect(fileSize == "2.1 MB (2,240,988 bytes)")
     }
     
-    @Test func exifOption() async throws {
-        let json = try await perform(options: ["--exif"])
+    @Test("--no-iptc --no-tiff --no-gps yields only EXIF metadata")
+    func exifOnly() async throws {
+        let json = try await perform(options: ["--no-iptc", "--no-tiff", "--no-gps"])
 
         #expect(json["iptc"] == nil)
         #expect(json["tiff"] == nil)
         #expect(json["gps"] == nil)
-        
+
         let exif = try #require(json["exif"] as? [String: Any])
         #expect(JSONSerialization.isValidJSONObject(exif) == true)
-        
+
         let dateTimeOriginal = try #require(exif["dateTimeOriginal"] as? String)
-        
+
         #expect(dateTimeOriginal == "1826-06-01T12:00:00.199+0200")
-        
+
         let offsetTimeOriginal = try #require(exif["offsetTimeOriginal"] as? String)
         #expect(offsetTimeOriginal == "+02:00")
     }
-    
-    @Test func iptcOption() async throws {
-        let json = try await perform(options: ["--iptc"])
-        
+
+    @Test("--no-exif --no-tiff --no-gps yields only IPTC metadata")
+    func iptcOnly() async throws {
+        let json = try await perform(options: ["--no-exif", "--no-tiff", "--no-gps"])
+
         #expect(json["exif"] == nil)
         #expect(json["tiff"] == nil)
         #expect(json["gps"] == nil)
-        
+
         let iptc = try #require(json["iptc"] as? [String: Any])
         #expect(JSONSerialization.isValidJSONObject(iptc) == true)
-        
+
         let byline = try #require(iptc["byline"] as? [String])
         #expect(byline.first == "Joseph Nicéphore Niépce")
-        
+
         let captionAbstract = try #require(iptc["captionAbstract"] as? String)
         #expect(captionAbstract == "The earliest surviving camera photograph.")
-        
+
         let city = try #require(iptc["city"] as? String)
         #expect(city == "Saint-Loup-de-Varennes")
-        
+
         let copyrightNotice = try #require(iptc["copyrightNotice"] as? String)
         #expect(copyrightNotice == "Public Domain")
-        
+
         let country = try #require(iptc["country"] as? String)
         #expect(country == "France")
-        
+
         let headline = try #require(iptc["headline"] as? String)
         #expect(headline == "View from the Window at Le Gras")
     }
-    
-    @Test func tiffOption() async throws {
-        let json = try await perform(options: ["--tiff"])
-        
+
+    @Test("--no-exif --no-iptc --no-gps yields only TIFF metadata")
+    func tiffOnly() async throws {
+        let json = try await perform(options: ["--no-exif", "--no-iptc", "--no-gps"])
+
         #expect(json["exif"] == nil)
         #expect(json["iptc"] == nil)
         #expect(json["gps"] == nil)
-        
+
         let tiff = try #require(json["tiff"] as? [String: Any])
         #expect(JSONSerialization.isValidJSONObject(tiff) == true)
-        
+
         let artist = try #require(tiff["artist"] as? String)
         #expect(artist == "Joseph Nicéphore Niépce")
-        
+
         let copyright = try #require(tiff["copyright"] as? String)
         #expect(copyright == "Public Domain")
-        
+
         let imageDescription = try #require(tiff["imageDescription"] as? String)
         #expect(imageDescription == "The earliest surviving camera photograph.")
     }
-    
-    @Test func gpsOption() async throws {
-        let json = try await perform(options: ["--gps"])
-        
+
+    @Test("--no-exif --no-iptc --no-tiff yields only GPS metadata")
+    func gpsOnly() async throws {
+        let json = try await perform(options: ["--no-exif", "--no-iptc", "--no-tiff"])
+
         #expect(json["exif"] == nil)
         #expect(json["iptc"] == nil)
         #expect(json["tiff"] == nil)
-        
+
         let gps = try #require(json["gps"] as? [String: Any])
         #expect(JSONSerialization.isValidJSONObject(gps) == true)
-        
+
         let latitude = try #require(gps["latitude"] as? Double)
         #expect(latitude == 46.72519666666667)
-        
+
         let longitude = try #require(gps["longitude"] as? Double)
         #expect(longitude == -4.860291666666667)
-        
+
         let latitudeReference = try #require(gps["latitudeReference"] as? String)
         #expect(latitudeReference == "N")
-        
+
         let longitudeReference = try #require(gps["longitudeReference"] as? String)
         #expect(longitudeReference == "E")
-        
+
         let dateTime = try #require(gps["dateTime"] as? String)
         #expect(dateTime == "2025-02-13T15:02:45Z")
     }


### PR DESCRIPTION
## Summary
Two related changes that simplify the imgmd CLI surface:

### 1. Drop format-specific flags
The format-specific dictionaries (DNG, PNG, GIF, HEIC, JFIF, WebP, 8BIM) are auto-included via UTI matching whenever the file's content type matches. The corresponding flags (\`--dng\`, \`--png\`, \`--gif\`, \`--heic\`, \`--jfif\`, \`--webp\`, \`--8bim\`/\`--eight-bim\`) were redundant — removing them shrinks the help output and matches the user model: "give me the file's metadata; format-specific stuff appears when relevant."

8BIM auto-include now also fires for **JPEG and TIFF** (Photoshop embeds 8BIM blocks in those formats too), so Photoshop-touched files still surface their 8BIM data without needing a flag.

### 2. Flip cross-format defaults to on
Cross-format flag defaults flipped from \`false\` to \`true\` so the help text accurately reads \`(default: --exif)\` instead of the misleading \`(default: --no-exif)\`. The empty-then-fall-back-to-\`.all\` branch is no longer needed and was removed.

**Behavior shift:** passing a single flag like \`--exif\` used to mean "only EXIF" (because all other defaults were false); it's now a no-op confirmation. To narrow output, use the \`--no-X\` opt-out flags. The four \`xxxOption\` imgmdTests cases that exercised the "only-X" pattern were rewritten as \`xxxOnly\` tests using the new \`--no-X\` syntax.

## New help output
\`\`\`
USAGE: imgmd [--basic] [--exif] [--no-exif] [--gps] [--no-gps] [--iptc] [--no-iptc] [--tiff] [--no-tiff] [--debug] [<files> ...]

OPTIONS:
  -b, --basic             Basic. Don't include other metadata.
  -e, --exif/--no-exif    Include EXIF metadata. (default: --exif)
  -g, --gps/--no-gps      Include GPS metadata. (default: --gps)
  -i, --iptc/--no-iptc    Include IPTC metadata. (default: --iptc)
  -t, --tiff/--no-tiff    Include TIFF metadata. (default: --tiff)
  -d, --debug             Show the raw metadata.
  -h, --help              Show help information.
\`\`\`

## Test plan
- [x] \`swift build\` is clean.
- [x] \`swift test\` — 379 tests pass (4 imgmdTests cases rewritten for the new opt-out pattern).
- [x] Manual: \`imgmd --basic <file>\` still strips all metadata blocks.
- [x] Manual: \`imgmd <file>\` still shows everything (cross-format + auto-included format-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)